### PR TITLE
Fix clean-tree release guard

### DIFF
--- a/build-installer.ps1
+++ b/build-installer.ps1
@@ -18,7 +18,8 @@ function Assert-CleanGitTree {
     [string] $Path
   )
 
-  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue
+  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1
   if (-not $git) {
     throw "Git was not found. Install Git or omit -RequireCleanTree."
   }

--- a/publish-app.ps1
+++ b/publish-app.ps1
@@ -16,7 +16,8 @@ function Assert-CleanGitTree {
     [string] $Path
   )
 
-  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue
+  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1
   if (-not $git) {
     throw "Git was not found. Install Git or omit -RequireCleanTree."
   }

--- a/test-release-gate.ps1
+++ b/test-release-gate.ps1
@@ -59,7 +59,8 @@ function Assert-CleanGitTree {
     [string] $Path
   )
 
-  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue
+  $git = Get-Command git -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1
   if (-not $git) {
     throw "Git was not found. Install Git or omit -RequireCleanTree."
   }

--- a/tests/LocalLlmConsole.Tests/ReleaseHardening.Release.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/ReleaseHardening.Release.Tests.cs
@@ -196,6 +196,7 @@ public sealed partial class ReleaseHardeningTests
         {
             Assert.Contains("[switch] $RequireCleanTree", script, StringComparison.Ordinal);
             Assert.Contains("function Assert-CleanGitTree", script, StringComparison.Ordinal);
+            Assert.Contains("Select-Object -First 1", script, StringComparison.Ordinal);
             Assert.Contains("status --porcelain --untracked-files=all", script, StringComparison.Ordinal);
             Assert.Contains("Release requires a clean Git worktree", script, StringComparison.Ordinal);
         }


### PR DESCRIPTION
## Summary

- Resolves one Git executable deterministically when multiple `git.exe` installations are present on `PATH`.
- Applies the fix consistently to the release gate, portable publisher, and installer builder.
- Adds a regression assertion for all three clean-tree guards.

## Why

The v2.2.0 clean-main artifact build exposed that `Get-Command git` can return multiple applications. PowerShell then combined both paths and failed before checking repository cleanliness.

## Validation

- `ReleaseScriptsCanRequireCleanGitTree`: 1/1 passed.
- `git diff --check`: passed.
