### PR TITLE
Add support button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ endpoints on native Windows or Ubuntu/WSL.
 · [Read the documentation](docs/DEVELOPMENT.md)
 · [Automate with `llwmctl`](docs/CONTROL_API.md)
 
+<p align="center">
+  <a href="https://buymeacoffee.com/alekkson">
+    <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy me a coffee" width="217">
+  </a>
+</p>
+
 ![llama.cpp Windows Manager product tour](docs/images/llama-cpp-windows-manager-demo.gif)
 
 ## Why use llama.cpp Windows Manager?


### PR DESCRIPTION
## What changed

Added an official Buy Me a Coffee button near the top of the README, between the primary navigation links and the product tour.

## Why

This makes the optional project support link visible without interrupting the introduction or feature overview.

## Impact

Documentation only. The button links to `https://buymeacoffee.com/alekkson` and uses the official Buy Me a Coffee CDN image.

## Validation

* Verified the destination and image return HTTP 200
* `git diff --check`