### PR TITLE
Move automation scripts out of root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: Restore and build
         shell: pwsh
-        run: .\build-app.ps1 -Restore
+        run: .\scripts\build-app.ps1 -Restore
 
       - name: Test and enforce coverage
         shell: pwsh
-        run: .\test-coverage.ps1
+        run: .\scripts\test-coverage.ps1
 
       - name: Verify formatting
         shell: pwsh
@@ -40,11 +40,11 @@ jobs:
 
       - name: Package security and currency audit
         shell: pwsh
-        run: .\test-vulnerabilities.ps1
+        run: .\scripts\test-vulnerabilities.ps1
 
       - name: Publish smoke
         shell: pwsh
-        run: .\publish-app.ps1
+        run: .\scripts\publish-app.ps1
 
       - name: Verify publish contents
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run signed release gate
         shell: pwsh
         run: >-
-          .\test-release-gate.ps1 -Configuration Release -Runtime win-x64
+          .\scripts\test-release-gate.ps1 -Configuration Release -Runtime win-x64
           -IncludePublish -IncludeInstaller -InnoSetupPath "${{ steps.inno.outputs.path }}"
           -CertificateThumbprint "${{ steps.signing.outputs.thumbprint }}"
           -RequireSigned

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,8 @@ boundaries. Run tests proportional to the change and the full gate for control,
 architecture, packaging, or release work:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-app.ps1 -Restore
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1
 ```
 
 Before launching a source build, check `llwmctl status`; it cannot run beside a

--- a/README.md
+++ b/README.md
@@ -153,16 +153,16 @@ SDK selected by `global.json`. Inno Setup 6 is required only for installer
 builds.
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-app.ps1 -Restore
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1
 ```
 
 Add `-IncludePublish` to validate the portable package and
 `-IncludeInstaller` on a machine configured with Inno Setup. Generated `bin`,
 `obj`, `TestResults`, `dist`, logs, local workspaces, databases, and model files
-are ignored by Git. Use `clean-repo.ps1` to remove generated output.
+are ignored by Git. Use `scripts/clean-repo.ps1` to remove generated output.
 
-Create the installer directly with `build-installer.ps1` after configuring
+Create the installer directly with `scripts/build-installer.ps1` after configuring
 Inno Setup and, for trusted releases, the signing certificate.
 
 Architecture and contribution details are in

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -156,16 +156,16 @@ The core release blockers from the full audit have been addressed in code:
 Current passing checks:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-app.ps1 -Restore
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-app.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-vulnerabilities.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\publish-app.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1 -SkipPublish
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-app.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-vulnerabilities.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\publish-app.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -SkipPublish
 ```
 
 The latest source architecture/release pass on 2026-08-15 ran
-`test-release-gate.ps1 -IncludePublish -IncludeInstaller`, which wraps the Release build,
+`scripts/test-release-gate.ps1 -IncludePublish -IncludeInstaller`, which wraps the Release build,
 release-hardening suite, coverage enforcement, formatting verification,
 `git diff --check`, direct-package vulnerability/deprecation/currency checks,
 the portable packaging gate, and the installer gate. Service/unit tests passed (`548/548`) and the
@@ -213,7 +213,7 @@ low-risk items that were safe to take immediately:
 Verification for this hardening pass:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller
 ```
 
 Result on 2026-06-01: release-hardening tests passed (`432/432`), formatting was

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,7 +17,7 @@ models, or llama.cpp runtimes.
 git clone https://github.com/alekk89/llama-cpp-windows-manager.git
 Set-Location llama-cpp-windows-manager
 Get-Content AGENTS.md
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File ./build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File ./scripts/build-app.ps1 -Restore
 ```
 
 Before launching a source build, check whether the single-instance production
@@ -50,17 +50,17 @@ request only after that GitHub mutation has been requested.
 Run these before opening a release PR or after any architecture-level change:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1
 ```
 
 That wrapper runs the same gate as the individual commands below:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-app.ps1 -Restore
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-coverage.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-coverage.ps1
 dotnet format LocalLlmConsole.sln --verify-no-changes --no-restore --verbosity minimal
 git diff --check
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-vulnerabilities.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-vulnerabilities.ps1
 ```
 
 The coverage gate collects instrumented Debug binaries (public Release binaries intentionally omit PDBs), rejects skipped tests, and requires at least 80% service line
@@ -74,11 +74,11 @@ LocalLlmConsole.sln`.
 To include packaging on a machine with publish/installer prerequisites, run:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller
 ```
 
-Use `-RequireCleanTree` on `test-release-gate.ps1`, `publish-app.ps1`, or
-`build-installer.ps1` when producing release artifacts that must come from a
+Use `-RequireCleanTree` on `scripts/test-release-gate.ps1`,
+`scripts/publish-app.ps1`, or `scripts/build-installer.ps1` when producing release artifacts that must come from a
 clean Git worktree.
 
 If `dotnet` is not on `PATH`, set `LLAMA_CPP_WINDOWS_MANAGER_DOTNET` to a .NET

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -17,13 +17,13 @@ The legacy `LLAMA_CPP_CONSOLE_INNO_SETUP` variable is still accepted.
 Then run:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1
 ```
 
 For a public build, sign the app and installer:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
 ```
 
 The setup executable is written to:

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -7,31 +7,31 @@ Last updated: 2026-08-15
 Run from a clean checkout with the .NET 10 SDK selected by `global.json` on `PATH`, or set `LLAMA_CPP_WINDOWS_MANAGER_DOTNET` to an explicit SDK `dotnet.exe`. The legacy `LLAMA_CPP_CONSOLE_DOTNET` and `LOCAL_LLM_CONSOLE_DOTNET` variables are still accepted.
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-app.ps1 -Restore
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-coverage.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-vulnerabilities.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\publish-app.ps1
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-app.ps1 -Restore
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-coverage.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-vulnerabilities.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\publish-app.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1
 ```
 
 The same source-level gate can be run through the local wrapper, with packaging
 included when the machine has Inno Setup and any required signing certificate:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller
 ```
 
-Add `-RequireCleanTree` to `test-release-gate.ps1`, `publish-app.ps1`, or
-`build-installer.ps1` when packaging release artifacts; the scripts fail if
+Add `-RequireCleanTree` to `scripts/test-release-gate.ps1`,
+`scripts/publish-app.ps1`, or `scripts/build-installer.ps1` when packaging release artifacts; the scripts fail if
 `git status --porcelain --untracked-files=all` reports any tracked or untracked
 worktree changes.
 
 Trusted signed release builds use:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\publish-app.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\publish-app.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
 ```
 
 Trusted signed GitHub release builds may run `.github/workflows/release.yml`
@@ -298,7 +298,7 @@ companions, and be described as unsigned.
 Current local check on 2026-08-15:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller
 ```
 
 Result: .NET 10 Release app and CLI builds succeeded with zero warnings;

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -8,12 +8,12 @@ they are linked. The release scripts support signing with a certificate already
 available in the Windows certificate store:
 
 ```powershell
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\publish-app.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\test-release-gate.ps1 -IncludePublish -IncludeInstaller -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\publish-app.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\build-installer.ps1 -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish -IncludeInstaller -CertificateThumbprint "<cert-thumbprint>" -RequireSigned
 ```
 
-When `build-installer.ps1 -SkipPublish -RequireSigned` reuses an existing
+When `scripts/build-installer.ps1 -SkipPublish -RequireSigned` reuses an existing
 publish folder, the script verifies that the published executable is already
 signed before compiling and signing the installer.
 

--- a/scripts/build-app.ps1
+++ b/scripts/build-app.ps1
@@ -5,7 +5,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$AppDir = Split-Path -Parent $PSScriptRoot
 $Project = Join-Path $AppDir "src\LocalLlmConsole.App\LocalLlmConsole.App.csproj"
 $CliProject = Join-Path $AppDir "src\LocalLlmConsole.ControlCli\LocalLlmConsole.ControlCli.csproj"
 $BundledDotnet = Join-Path (Split-Path -Parent $AppDir) ".dotnet-sdk-10\dotnet.exe"

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -119,13 +119,13 @@ function Assert-SignedIfRequired([string] $PathToCheck, [bool] $RequireValidSign
   }
 }
 
-$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$AppDir = Split-Path -Parent $PSScriptRoot
 if ($RequireCleanTree) {
   Assert-CleanGitTree -Path $AppDir
 }
 
 $Project = Join-Path $AppDir "src\LocalLlmConsole.App\LocalLlmConsole.App.csproj"
-$PublishScript = Join-Path $AppDir "publish-app.ps1"
+$PublishScript = Join-Path $PSScriptRoot "publish-app.ps1"
 $InstallerScript = Join-Path $AppDir "installer\LlamaCppWindowsManager.iss"
 $DistRoot = [System.IO.Path]::GetFullPath((Join-Path $AppDir "dist"))
 $PublishDir = [System.IO.Path]::GetFullPath((Join-Path $DistRoot "LlamaCppWindowsManager-$Runtime"))

--- a/scripts/clean-repo.ps1
+++ b/scripts/clean-repo.ps1
@@ -5,7 +5,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$RepoRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $MyInvocation.MyCommand.Definition))
+$RepoRoot = [System.IO.Path]::GetFullPath((Split-Path -Parent $PSScriptRoot))
 
 function Remove-RepoPath {
   param(

--- a/scripts/publish-app.ps1
+++ b/scripts/publish-app.ps1
@@ -66,7 +66,7 @@ function Remove-DistPath {
   }
 }
 
-$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$AppDir = Split-Path -Parent $PSScriptRoot
 if ($RequireCleanTree) {
   Assert-CleanGitTree -Path $AppDir
 }

--- a/scripts/start-app.ps1
+++ b/scripts/start-app.ps1
@@ -4,7 +4,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$AppDir = Split-Path -Parent $PSScriptRoot
 $PublishedExe = Join-Path $AppDir "dist\LlamaCppWindowsManager-win-x64\LlamaCppWindowsManager.exe"
 $BuildExe = Join-Path $AppDir "src\LocalLlmConsole.App\bin\Release\net10.0-windows\win-x64\LlamaCppWindowsManager.exe"
 $PowerShellExe = Join-Path $env:WINDIR "System32\WindowsPowerShell\v1.0\powershell.exe"
@@ -16,12 +16,12 @@ if (-not (Test-Path -LiteralPath $PowerShellExe)) {
 }
 
 if (-not (Test-Path -LiteralPath $PublishedExe) -and $PublishIfMissing) {
-  & $PowerShellExe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $AppDir "publish-app.ps1")
+  & $PowerShellExe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "publish-app.ps1")
 }
 
 $Exe = if (Test-Path -LiteralPath $PublishedExe) { $PublishedExe } elseif (Test-Path -LiteralPath $BuildExe) { $BuildExe } else { "" }
 if ([string]::IsNullOrWhiteSpace($Exe)) {
-  throw "llama.cpp Windows Manager executable not found. Run .\publish-app.ps1 after installing the .NET 10 SDK."
+  throw "llama.cpp Windows Manager executable not found. Run .\scripts\publish-app.ps1 after installing the .NET 10 SDK."
 }
 
 Start-Process -FilePath $Exe -WorkingDirectory $AppDir | Out-Null

--- a/scripts/test-app.ps1
+++ b/scripts/test-app.ps1
@@ -5,7 +5,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$AppDir = Split-Path -Parent $PSScriptRoot
 $TestProject = Join-Path $AppDir "tests\LocalLlmConsole.Tests\LocalLlmConsole.Tests.csproj"
 $BundledDotnet = Join-Path (Split-Path -Parent $AppDir) ".dotnet-sdk-10\dotnet.exe"
 $Dotnet = if ($env:LLAMA_CPP_WINDOWS_MANAGER_DOTNET) {

--- a/scripts/test-coverage.ps1
+++ b/scripts/test-coverage.ps1
@@ -6,7 +6,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = Split-Path -Parent $PSScriptRoot
 $TestProjects = @(
   (Join-Path $RepoRoot "tests\LocalLlmConsole.Tests\LocalLlmConsole.Tests.csproj"),
   (Join-Path $RepoRoot "tests\LocalLlmConsole.UiTests\LocalLlmConsole.UiTests.csproj")

--- a/scripts/test-release-gate.ps1
+++ b/scripts/test-release-gate.ps1
@@ -14,7 +14,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = Split-Path -Parent $PSScriptRoot
 
 function Resolve-Dotnet {
   $bundledDotnet = Join-Path (Split-Path -Parent $RepoRoot) ".dotnet-sdk-10\dotnet.exe"
@@ -233,7 +233,7 @@ $buildArgs = @(
   "-ExecutionPolicy",
   "Bypass",
   "-File",
-  (Join-Path $RepoRoot "build-app.ps1"),
+  (Join-Path $PSScriptRoot "build-app.ps1"),
   "-Configuration",
   $Configuration
 )
@@ -248,7 +248,7 @@ Invoke-GateStep "Build app" {
 Invoke-GateStep "Run tests and enforce coverage" {
   # Release binaries deliberately omit PDBs. Coverage is collected from the same
   # source in Debug while the separate build step enforces Release compilation.
-  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "test-coverage.ps1") -Configuration Debug
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "test-coverage.ps1") -Configuration Debug
 }
 
 Invoke-GateStep "Verify formatting" {
@@ -260,7 +260,7 @@ Invoke-GateStep "Check diff whitespace" {
 }
 
 Invoke-GateStep "Audit package vulnerabilities" {
-  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "test-vulnerabilities.ps1") -Configuration $Configuration
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "test-vulnerabilities.ps1") -Configuration $Configuration
 }
 
 if ($IncludePublish) {
@@ -269,7 +269,7 @@ if ($IncludePublish) {
     "-ExecutionPolicy",
     "Bypass",
     "-File",
-    (Join-Path $RepoRoot "publish-app.ps1"),
+    (Join-Path $PSScriptRoot "publish-app.ps1"),
     "-Runtime",
     $Runtime,
     "-Configuration",
@@ -300,7 +300,7 @@ if ($IncludeInstaller) {
     "-ExecutionPolicy",
     "Bypass",
     "-File",
-    (Join-Path $RepoRoot "build-installer.ps1"),
+    (Join-Path $PSScriptRoot "build-installer.ps1"),
     "-Runtime",
     $Runtime,
     "-Configuration",

--- a/scripts/test-vulnerabilities.ps1
+++ b/scripts/test-vulnerabilities.ps1
@@ -5,7 +5,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 function Resolve-Dotnet {
-  $appDir = $PSScriptRoot
+  $appDir = Split-Path -Parent $PSScriptRoot
   $bundledDotnet = Join-Path (Split-Path -Parent $appDir) ".dotnet-sdk-10\dotnet.exe"
   if ($env:LLAMA_CPP_WINDOWS_MANAGER_DOTNET) {
     return $env:LLAMA_CPP_WINDOWS_MANAGER_DOTNET
@@ -92,7 +92,7 @@ function Count-Properties($node, [string] $propertyName) {
   return $count
 }
 
-$appDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$appDir = Split-Path -Parent $PSScriptRoot
 $projects = @(
   (Join-Path $appDir "src\LocalLlmConsole.App\LocalLlmConsole.App.csproj"),
   (Join-Path $appDir "src\LocalLlmConsole.ControlCli\LocalLlmConsole.ControlCli.csproj"),

--- a/tests/LocalLlmConsole.Tests/ReleaseHardening.AgentSidecars.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/ReleaseHardening.AgentSidecars.Tests.cs
@@ -149,8 +149,8 @@ public sealed partial class ReleaseHardeningTests
     {
         var project = File.ReadAllText(FindRepositoryFile("src", "LocalLlmConsole.App", "LocalLlmConsole.App.csproj"));
         var startup = File.ReadAllText(FindRepositoryFile("src", "LocalLlmConsole.App", "App.xaml.cs"));
-        var publish = File.ReadAllText(FindRepositoryFile("publish-app.ps1"));
-        var releaseGate = File.ReadAllText(FindRepositoryFile("test-release-gate.ps1"));
+        var publish = File.ReadAllText(FindRepositoryFile("scripts", "publish-app.ps1"));
+        var releaseGate = File.ReadAllText(FindRepositoryFile("scripts", "test-release-gate.ps1"));
         var releaseWorkflow = File.ReadAllText(FindRepositoryFile(".github", "workflows", "release.yml"));
         var installer = File.ReadAllText(FindRepositoryFile("installer", "LlamaCppWindowsManager.iss"));
 

--- a/tests/LocalLlmConsole.Tests/ReleaseHardening.Release.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/ReleaseHardening.Release.Tests.cs
@@ -64,9 +64,9 @@ public sealed partial class ReleaseHardeningTests
     public void ReleaseDocsAndScriptsUseLaunchBranding()
     {
         var readme = File.ReadAllText(FindRepositoryFile("README.md"));
-        var buildScript = File.ReadAllText(FindRepositoryFile("build-app.ps1"));
-        var publishScript = File.ReadAllText(FindRepositoryFile("publish-app.ps1"));
-        var startScript = File.ReadAllText(FindRepositoryFile("start-app.ps1"));
+        var buildScript = File.ReadAllText(FindRepositoryFile("scripts", "build-app.ps1"));
+        var publishScript = File.ReadAllText(FindRepositoryFile("scripts", "publish-app.ps1"));
+        var startScript = File.ReadAllText(FindRepositoryFile("scripts", "start-app.ps1"));
         var architecture = File.ReadAllText(FindRepositoryFile("docs", "ARCHITECTURE.md"));
         var license = File.ReadAllText(FindRepositoryFile("LICENSE"));
         var publicDocs = string.Join(
@@ -110,22 +110,22 @@ public sealed partial class ReleaseHardeningTests
         var editorConfig = File.ReadAllText(FindRepositoryFile(".editorconfig"));
         var gitAttributes = File.ReadAllText(FindRepositoryFile(".gitattributes"));
         var solution = File.ReadAllText(FindRepositoryFile("LocalLlmConsole.sln"));
-        var releaseGate = File.ReadAllText(FindRepositoryFile("test-release-gate.ps1"));
+        var releaseGate = File.ReadAllText(FindRepositoryFile("scripts", "test-release-gate.ps1"));
         var development = File.ReadAllText(FindRepositoryFile("docs", "DEVELOPMENT.md"));
 
         Assert.Contains("windows-latest", workflow, StringComparison.Ordinal);
         Assert.Contains("actions/checkout@v7", workflow, StringComparison.Ordinal);
         Assert.Contains("actions/setup-dotnet@v6", workflow, StringComparison.Ordinal);
-        Assert.Contains(".\\build-app.ps1 -Restore", workflow, StringComparison.Ordinal);
-        Assert.Contains(".\\test-coverage.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains(".\\scripts\\build-app.ps1 -Restore", workflow, StringComparison.Ordinal);
+        Assert.Contains(".\\scripts\\test-coverage.ps1", workflow, StringComparison.Ordinal);
         Assert.Contains("dotnet format LocalLlmConsole.sln --verify-no-changes --verbosity minimal", workflow, StringComparison.Ordinal);
         Assert.Contains("git diff --check", workflow, StringComparison.Ordinal);
-        Assert.Contains(".\\test-vulnerabilities.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains(".\\scripts\\test-vulnerabilities.ps1", workflow, StringComparison.Ordinal);
         Assert.Contains("checksum was not produced", workflow, StringComparison.Ordinal);
-        Assert.Contains("package --vulnerable --include-transitive --format json", File.ReadAllText(FindRepositoryFile("test-vulnerabilities.ps1")), StringComparison.Ordinal);
-        Assert.Contains("package --outdated --format json", File.ReadAllText(FindRepositoryFile("test-vulnerabilities.ps1")), StringComparison.Ordinal);
-        Assert.Contains("package --deprecated --include-transitive --format json", File.ReadAllText(FindRepositoryFile("test-vulnerabilities.ps1")), StringComparison.Ordinal);
-        Assert.Contains(".\\publish-app.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains("package --vulnerable --include-transitive --format json", File.ReadAllText(FindRepositoryFile("scripts", "test-vulnerabilities.ps1")), StringComparison.Ordinal);
+        Assert.Contains("package --outdated --format json", File.ReadAllText(FindRepositoryFile("scripts", "test-vulnerabilities.ps1")), StringComparison.Ordinal);
+        Assert.Contains("package --deprecated --include-transitive --format json", File.ReadAllText(FindRepositoryFile("scripts", "test-vulnerabilities.ps1")), StringComparison.Ordinal);
+        Assert.Contains(".\\scripts\\publish-app.ps1", workflow, StringComparison.Ordinal);
         Assert.Contains("\"version\": \"10.0.400\"", globalJson, StringComparison.Ordinal);
         Assert.Contains("\"runner\": \"Microsoft.Testing.Platform\"", globalJson, StringComparison.Ordinal);
         Assert.Contains("TreatWarningsAsErrors", File.ReadAllText(FindRepositoryFile("Directory.Build.props")), StringComparison.Ordinal);
@@ -139,10 +139,10 @@ public sealed partial class ReleaseHardeningTests
         Assert.Contains("LocalLlmConsole.UiTests.csproj", solution, StringComparison.Ordinal);
         Assert.Contains("build-app.ps1", releaseGate, StringComparison.Ordinal);
         Assert.Contains("test-coverage.ps1", releaseGate, StringComparison.Ordinal);
-        Assert.Contains("MinimumServiceLineCoverage = 80.0", File.ReadAllText(FindRepositoryFile("test-coverage.ps1")), StringComparison.Ordinal);
-        Assert.Contains("MinimumModelLineCoverage = 95.0", File.ReadAllText(FindRepositoryFile("test-coverage.ps1")), StringComparison.Ordinal);
-        Assert.Contains("Skipped or not-executed tests are not allowed", File.ReadAllText(FindRepositoryFile("test-coverage.ps1")), StringComparison.Ordinal);
-        Assert.Contains("LocalLlmConsole.App/", File.ReadAllText(FindRepositoryFile("test-coverage.ps1")), StringComparison.Ordinal);
+        Assert.Contains("MinimumServiceLineCoverage = 80.0", File.ReadAllText(FindRepositoryFile("scripts", "test-coverage.ps1")), StringComparison.Ordinal);
+        Assert.Contains("MinimumModelLineCoverage = 95.0", File.ReadAllText(FindRepositoryFile("scripts", "test-coverage.ps1")), StringComparison.Ordinal);
+        Assert.Contains("Skipped or not-executed tests are not allowed", File.ReadAllText(FindRepositoryFile("scripts", "test-coverage.ps1")), StringComparison.Ordinal);
+        Assert.Contains("LocalLlmConsole.App/", File.ReadAllText(FindRepositoryFile("scripts", "test-coverage.ps1")), StringComparison.Ordinal);
         Assert.Contains("dotnet format", releaseGate, StringComparison.Ordinal);
         Assert.Contains("git -C $RepoRoot diff --check", releaseGate, StringComparison.Ordinal);
         Assert.Contains("test-vulnerabilities.ps1", releaseGate, StringComparison.Ordinal);
@@ -164,14 +164,40 @@ public sealed partial class ReleaseHardeningTests
         Assert.Matches(@"actions/checkout@[0-9a-f]{40}\s+# v7", releaseWorkflow);
         Assert.Matches(@"actions/setup-dotnet@[0-9a-f]{40}\s+# v6", releaseWorkflow);
         Assert.Matches(@"actions/upload-artifact@[0-9a-f]{40}\s+# v7", releaseWorkflow);
-        Assert.Contains(".\\test-release-gate.ps1", development, StringComparison.Ordinal);
+        Assert.Contains(".\\scripts\\test-release-gate.ps1", development, StringComparison.Ordinal);
         Assert.Contains("-IncludePublish -IncludeInstaller", development, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RepositoryKeepsAutomationScriptsOutOfRoot()
+    {
+        var repositoryRoot = Path.GetDirectoryName(FindRepositoryFile("README.md"))!;
+        var rootScripts = Directory.EnumerateFiles(repositoryRoot, "*.ps1", SearchOption.TopDirectoryOnly);
+        var automationScripts = Directory.EnumerateFiles(Path.Combine(repositoryRoot, "scripts"), "*.ps1", SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(rootScripts);
+        Assert.Equal(
+            [
+                "build-app.ps1",
+                "build-installer.ps1",
+                "clean-repo.ps1",
+                "publish-app.ps1",
+                "start-app.ps1",
+                "test-app.ps1",
+                "test-coverage.ps1",
+                "test-release-gate.ps1",
+                "test-vulnerabilities.ps1"
+            ],
+            automationScripts);
     }
 
     [Fact]
     public void BuildInstallerRequiresSignedPublishedExecutableForSignedInstaller()
     {
-        var buildInstaller = File.ReadAllText(FindRepositoryFile("build-installer.ps1"));
+        var buildInstaller = File.ReadAllText(FindRepositoryFile("scripts", "build-installer.ps1"));
 
         Assert.Contains("[string] $TimestampServer = \"https://timestamp.digicert.com\"", buildInstaller, StringComparison.Ordinal);
         Assert.DoesNotContain("http://timestamp.digicert.com", buildInstaller, StringComparison.Ordinal);
@@ -186,9 +212,9 @@ public sealed partial class ReleaseHardeningTests
     [Fact]
     public void ReleaseScriptsCanRequireCleanGitTree()
     {
-        var releaseGate = File.ReadAllText(FindRepositoryFile("test-release-gate.ps1"));
-        var publishScript = File.ReadAllText(FindRepositoryFile("publish-app.ps1"));
-        var buildInstaller = File.ReadAllText(FindRepositoryFile("build-installer.ps1"));
+        var releaseGate = File.ReadAllText(FindRepositoryFile("scripts", "test-release-gate.ps1"));
+        var publishScript = File.ReadAllText(FindRepositoryFile("scripts", "publish-app.ps1"));
+        var buildInstaller = File.ReadAllText(FindRepositoryFile("scripts", "build-installer.ps1"));
         var development = File.ReadAllText(FindRepositoryFile("docs", "DEVELOPMENT.md"));
         var releaseReadiness = File.ReadAllText(FindRepositoryFile("docs", "RELEASE_READINESS.md"));
 
@@ -215,7 +241,7 @@ public sealed partial class ReleaseHardeningTests
     [Fact]
     public void PublishScriptUsesSafeDistCleanup()
     {
-        var publishScript = File.ReadAllText(FindRepositoryFile("publish-app.ps1"));
+        var publishScript = File.ReadAllText(FindRepositoryFile("scripts", "publish-app.ps1"));
 
         Assert.Contains("$publishArgs = @(", publishScript, StringComparison.Ordinal);
         Assert.Contains("& $Dotnet @publishArgs", publishScript, StringComparison.Ordinal);
@@ -234,7 +260,7 @@ public sealed partial class ReleaseHardeningTests
     public void InstallerKeepsUserDataUnlessExplicitlyRequested()
     {
         var installer = File.ReadAllText(FindRepositoryFile("installer", "LlamaCppWindowsManager.iss"));
-        var buildInstaller = File.ReadAllText(FindRepositoryFile("build-installer.ps1"));
+        var buildInstaller = File.ReadAllText(FindRepositoryFile("scripts", "build-installer.ps1"));
         var installerDocs = File.ReadAllText(FindRepositoryFile("docs", "INSTALLER.md"));
         var readme = File.ReadAllText(FindRepositoryFile("README.md"));
         var releaseReadiness = File.ReadAllText(FindRepositoryFile("docs", "RELEASE_READINESS.md"));


### PR DESCRIPTION
## What changed

Moved all nine PowerShell build, test, packaging, launch, and cleanup entry points into `scripts/`. Updated their repository-root resolution, sibling-script calls, CI and release workflows, operator/developer documentation, README commands, and path-sensitive release-hardening tests.

## Why

The repository root was visually dominated by automation scripts. Grouping them under one directory keeps the GitHub root concise without deleting or hiding required tooling.

## Impact

Commands now use paths such as `.\scripts\build-app.ps1` and `.\scripts\test-release-gate.ps1`. Standard root-level .NET, NuGet, Git, licensing, solution, and documentation files remain in place. A regression test now requires the repository root to contain no `.ps1` files.

## Validation

* PowerShell parsing passed for all nine scripts
* Moved build entry point passed with zero warnings or errors
* Root-layout regression test passed
* Full release gate passed: 549 core tests and 1 WPF test, zero failures and zero skips
* Coverage passed: Services 80.9%, Models and ViewModels 97.4%
* Formatting, whitespace, dependency, vulnerability, portable publish, checksum, installer, and cleanup checks passed