### PR TITLE
Polish v2.5.0 release notes

### DIFF
--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -1,13 +1,9 @@
-Version 2.5 turns benchmarking into a proper part of the Manager. You can test saved profiles exactly as you use them, or run direct `llama-bench` measurements when you want to dig deeper. Workload presets, capability checks, GPU and speculative decoding comparisons, pausing, resuming, result comparisons, and CSV or JSON exports are all built in.
+- v2.5 introduces benchmarking directly in the Manager. Test the profiles you already use or run direct `llama-bench` measurements, with workload presets, capability checks, GPU and speculative decoding comparisons, pausing and resuming, and CSV or JSON exports all built in.
+- Favourite launch profiles now live in the tray, making it much quicker to load, stop, or switch models without reopening the main window. Your favourites stick around, the menu follows your theme, and it does no work until you open it.
+- Benchmark runs are managed by the app, so you can navigate away while one is running and come back whenever you like. Interrupted runs keep their partial results, and completed runs can be inspected, cloned, compared, or automated through `llwmctl` and the Control API.
+- Embedded MTP models now work as a single GGUF. Choose `draft-mtp` and leave the draft model on Automatic, and the Manager will use the embedded NextN tensors instead of asking for a separate companion file.
+- The app uses fewer resources in the background and behaves better when several things happen at once. Inactive screens release their content, model load and stop requests cannot trip over each other, downloads stay within sensible limits, and failed process starts clean up after themselves.
+- Keyboard navigation and Windows high contrast support have had a proper pass. Overview cards can be moved, resized, and reordered from the keyboard, while the Models page is much easier to use in a narrow window.
+- Updates now check release manifests, publisher details, file hashes, and asset information before installing. Installer updates and repairs continue to preserve your models, runtimes, profiles, settings, metrics, and sessions.
 
-Favourite launch profiles now live in the tray, so loading, stopping, and switching models no longer means reopening the main window. Your favourites persist, the menu follows the application theme, and it stays completely idle while closed.
-
-Benchmark runs belong to the Manager rather than the page that started them. You can navigate away without losing a run, keep partial results after an interruption, and come back later to inspect, clone, resume, compare, or automate the work through `llwmctl` and the Control API.
-
-The application is lighter when sitting in the background and more dependable when several things happen at once. Inactive pages release their visual content, tray components load only when needed, model lifecycle changes cannot race each other, downloads stay bounded, and incomplete process starts are cleaned up properly.
-
-Keyboard navigation and Windows high contrast support have been improved throughout the application. The Overview dashboard can now be moved, resized, and reordered from the keyboard, and Models behaves much better in a narrow window.
-
-The update path now verifies signed release manifests, publisher identity, hashes, and asset details before installing anything. The v2.5 artifacts remain unsigned while the open source signing application is pending, so use the matching SHA 256 companion files to verify downloads.
-
-Installer updates and repairs preserve your existing models, runtimes, profiles, settings, metrics, and sessions.
+These builds are still unsigned while we wait for the new signing certificate. Please use the matching SHA-256 file to check your download.


### PR DESCRIPTION
Rewrites the v2.5.0 notes in the same concise bullet style as recent releases, adds the embedded MTP fix, and keeps the unsigned-build guidance clear.