### PR TITLE
Fix GPU power limit parsing

### DIFF
--- a/src/LocalLlmConsole.App/Ui/Pages/Overview/OverviewDashboardMetricRegistry.cs
+++ b/src/LocalLlmConsole.App/Ui/Pages/Overview/OverviewDashboardMetricRegistry.cs
@@ -178,7 +178,7 @@ public sealed partial class OverviewDashboardMetricRegistry
                 AddGpuReading(readings, GpuSensorDefinition(
                         OverviewDashboardMetricIds.GpuVram(index), index, "Dashboard.Metric.VramUsed"),
                     vram.Used, "0.0", "GiB", vram.Total, $"of {vram.Total:0.0} GiB · {gpuName}");
-            var powerWatts = FirstNumber(raw, @"(\d+(?:\.\d+)?)\s*W(?:\s|$)");
+            var powerWatts = FirstNumber(raw, @"(\d+(?:\.\d+)?)\s*W(?=\s*(?:/|\||$))");
             AddGpuReading(readings, GpuSensorDefinition(
                     OverviewDashboardMetricIds.GpuPower(index), index, "Dashboard.Metric.PowerDraw"),
                 powerWatts, "0.#", "W", detail: gpuName);

--- a/src/LocalLlmConsole.Core/Services/Infrastructure/HostHardwareSnapshotParser.cs
+++ b/src/LocalLlmConsole.Core/Services/Infrastructure/HostHardwareSnapshotParser.cs
@@ -84,7 +84,7 @@ public static class HostHardwareSnapshotParser
             Percentage(raw),
             capacity?.Used,
             capacity?.Total,
-            Number(raw, @"(\d+(?:\.\d+)?)\s*W(?:\s|$)"),
+            Number(raw, @"(\d+(?:\.\d+)?)\s*W(?=\s*(?:/|\||$))"),
             Number(raw, @"(\d+(?:\.\d+)?)\s*MHz(?:\s+core)?"),
             Number(raw, @"(\d+(?:\.\d+)?)\s*°\s*C"),
             Number(raw, @"(\d+(?:\.\d+)?)\s*°\s*C\s+(?:memory|VRAM)"),

--- a/tests/LocalLlmConsole.Tests/Telemetry/GpuEnergy.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Telemetry/GpuEnergy.Tests.cs
@@ -14,7 +14,7 @@ public sealed class GpuEnergyTests : ManagerRegressionTestBase
         var snapshot = HostHardwareSnapshotParser.Parse(
             "CPU: AMD Ryzen\nTelemetry: 12% load | 5100 MHz core | 16 cores | 32 threads\n"
             + "RAM: 50% load | 16.0/32.0 GiB | 6000 MHz\n"
-            + "GPU 0: NVIDIA RTX | 75% load | 20.0/24.0 GiB VRAM | 225 W | 1800 MHz core | 70 °C | 82 °C memory\n"
+            + "GPU 0: NVIDIA RTX | 75% load | 20.0/24.0 GiB VRAM | 225 W | 300 W limit | 1800 MHz core | 70 °C | 82 °C memory\n"
             + "Process: 4.5% CPU | 3.25 GiB private RAM",
             capturedAt);
 
@@ -22,12 +22,35 @@ public sealed class GpuEnergyTests : ManagerRegressionTestBase
         Assert.Equal(16, snapshot.Cpu?.PhysicalCores);
         Assert.Equal(16, snapshot.Memory?.UsedGibibytes);
         Assert.Equal(225, snapshot.Gpus.Single().PowerWatts);
+        Assert.Equal(300, snapshot.Gpus.Single().PowerLimitWatts);
         Assert.Equal(82, snapshot.Gpus.Single().MemoryTemperatureCelsius);
         Assert.Equal(3.25, snapshot.Process?.PrivateMemoryGibibytes);
 
         var power = GpuPowerObservationParser.Parse(snapshot, capturedAt);
         Assert.Equal(225, power.TotalWatts);
         Assert.Equal(1, power.DetectedGpuCount);
+    }
+
+    [Theory]
+    [InlineData("NVIDIA RTX 3090", 250)]
+    [InlineData("AMD Radeon RX 7900 XTX", 550)]
+    [InlineData("Intel Arc B580", 190)]
+    public void PowerLimitWithoutDrawIsNotRecordedAsGpuPower(string gpuName, double powerLimit)
+    {
+        var capturedAt = new DateTimeOffset(2026, 8, 29, 10, 0, 0, TimeSpan.Zero);
+        var snapshot = HostHardwareSnapshotParser.Parse(
+            $"GPU 0: {gpuName} | 50% load | {powerLimit:0.#} W limit",
+            capturedAt);
+
+        var gpu = Assert.Single(snapshot.Gpus);
+        Assert.Null(gpu.PowerWatts);
+        Assert.Equal(powerLimit, gpu.PowerLimitWatts);
+
+        var observation = GpuPowerObservationParser.Parse(snapshot, capturedAt);
+        Assert.Empty(observation.Sensors);
+        Assert.Equal(0, observation.TotalWatts);
+        Assert.Equal(0, observation.ObservedGpuCount);
+        Assert.Equal(1, observation.DetectedGpuCount);
     }
 
     [Fact]

--- a/tests/LocalLlmConsole.Tests/Telemetry/LiveMetricRecommendations.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Telemetry/LiveMetricRecommendations.Tests.cs
@@ -44,6 +44,7 @@ public sealed class LiveMetricRecommendationsTests : ManagerRegressionTestBase
         Assert.Contains(readings, reading => reading.MetricId == OverviewDashboardMetricIds.GpuMemoryActivity(0) && reading.Primary == 33);
         Assert.Contains(readings, reading => reading.MetricId == OverviewDashboardMetricIds.GpuFanSpeed(0) && reading.Primary == 40);
         Assert.Contains(readings, reading => reading.MetricId == OverviewDashboardMetricIds.GpuPowerLimit(0) && reading.Primary == 300);
+        Assert.DoesNotContain(readings, reading => reading.MetricId == OverviewDashboardMetricIds.GpuPower(0));
         Assert.Contains(readings, reading => reading.MetricId == OverviewDashboardMetricIds.GpuThrottling(0) && reading.Primary == 0);
     }
 


### PR DESCRIPTION
Prevents GPU power limits from being recorded as live draw when the hardware sensor is unavailable. Adds NVIDIA, AMD, and Intel regression coverage and protects GPU energy and electricity-cost totals from false samples.