### PR TITLE
Update pinned GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
           global-json-file: global.json
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: csharp
           build-mode: manual
@@ -45,6 +45,6 @@ jobs:
         run: .\scripts\build-app.ps1 -Restore -LockedRestore
 
       - name: Analyze
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: /language:csharp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           -RequireSigned
 
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: |
             dist/LlamaCppWindowsManager-win-x64/LlamaCppWindowsManager.exe


### PR DESCRIPTION
## Summary
- update both CodeQL action steps together from v4.37.7 to v4.37.9
- update attest-build-provenance from v2.4.0 to v3.0.0
- keep every workflow action pinned to an immutable upstream commit

This consolidates Dependabot PRs #37, #38, and #39 so CodeQL init/analyze cannot be validated at mismatched versions.

## Validation
- documentation validation passed
- 11 release repository policy tests passed
- git diff whitespace check passed