### PR TITLE
Skip trusted releases until signing is configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ vars.TRUSTED_RELEASE_ENABLED == 'true' }}
     name: Verify, sign, attest, and publish
     runs-on: windows-latest
     timeout-minutes: 45

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -50,6 +50,7 @@ Configure these protected-environment secrets:
 
 Configure these repository or protected-environment variables:
 
+- `TRUSTED_RELEASE_ENABLED=true` after every required release credential is configured;
 - `RELEASE_TAG_SIGNING_FINGERPRINT`;
 - `RELEASE_MANIFEST_KEY_ID`;
 - `RELEASE_MANIFEST_PUBLIC_KEY_SPKI`;

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -27,6 +27,10 @@ embedded version.
 
 Trusted stable builds use `.github/workflows/release.yml`, triggered by a signed
 annotated `v*` tag (or a manual dispatch that selects an existing signed tag).
+The trusted job runs only when the repository variable
+`TRUSTED_RELEASE_ENABLED` is set to `true`. Leave it unset while publishing
+explicitly labelled unsigned community releases; their tags then skip the
+trusted job without creating a failed `release` environment deployment.
 The protected `release` environment holds the PFX, trusted tag public key, and
 release-manifest private key. The workflow verifies the tag and protected-main
 reachability, runs the complete signed gate, validates upgrade from the pinned

--- a/tests/LocalLlmConsole.Tests/Release/ReleaseRepository.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Release/ReleaseRepository.Tests.cs
@@ -191,6 +191,7 @@ public sealed class ReleaseRepositoryTests : ManagerRegressionTestBase
         Assert.Contains("attest-build-provenance", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("gh release create", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("-RequireSigned", releaseWorkflow, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ vars.TRUSTED_RELEASE_ENABLED == 'true' }}", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("workflow_dispatch:", releaseWorkflow, StringComparison.Ordinal);
         Assert.Contains("tags:", releaseWorkflow, StringComparison.Ordinal);
         Assert.Matches(@"actions/checkout@[0-9a-f]{40}\s+# v7", releaseWorkflow);


### PR DESCRIPTION
## Summary
- gate the trusted release deployment behind the repository variable TRUSTED_RELEASE_ENABLED=true`n- let explicitly unsigned tag pushes skip without creating a failed release deployment
- document how to enable the protected signed path once every credential is configured
- add regression coverage for the workflow guard

## Validation
- documentation validation passed
- 11 release repository tests passed
- code-shape and whitespace checks passed