### PR TITLE
Keep installer upgrade checks from closing the GitHub runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,12 @@ jobs:
       - name: Test standalone portable EXE update
         shell: pwsh
         run: .\scripts\test-portable-update.ps1 -CandidateExePath .\dist\LlamaCppWindowsManager-win-x64\LlamaCppWindowsManager.exe
+
+      - name: Upload installer failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: installer-diagnostics-${{ github.run_id }}
+          path: TestResults/installer-upgrade
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/prepare-unsigned-release.yml
+++ b/.github/workflows/prepare-unsigned-release.yml
@@ -68,3 +68,12 @@ jobs:
           path: |
             dist/unsigned-v*/*
             docs/releases/${{ steps.stage.outputs.tag }}.md
+
+      - name: Upload installer failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: installer-diagnostics-${{ github.run_id }}
+          path: TestResults/installer-upgrade
+          if-no-files-found: ignore
+          retention-days: 14

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -114,6 +114,14 @@ publish-only gate is safe beside an installed Manager:
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish
 ```
 
+On GitHub Actions, the previous-version upgrade test shuts the Manager down
+through its control API, then prevents Inno Setup from closing or restarting
+other processes. Windows Restart Manager can identify the hosted runner's
+`provjobd.exe` as using the installed files; closing it disconnects the job.
+The test still rejects failed or reboot-deferred upgrades and verifies the new
+version, saved settings, restart, and uninstall. Normal installer behavior and
+local disposable-environment tests retain their default process handling.
+
 Use `-RequireCleanTree` on `scripts/test-release-gate.ps1`,
 `scripts/publish-app.ps1`, or `scripts/build-installer.ps1` when producing release artifacts that must come from a
 clean Git worktree.

--- a/scripts/test-previous-version-upgrade.ps1
+++ b/scripts/test-previous-version-upgrade.ps1
@@ -251,7 +251,7 @@ finally {
   }
   $resolved = [System.IO.Path]::GetFullPath($TestRoot)
   if ($cleanupUninstallFailed -or $upgradeFailed) {
-    Write-Warning "Preserving the failed upgrade-test root and diagnostics: $resolved"
+    Write-Warning "Preserving the temporary upgrade-test root and failure diagnostics: $resolved"
   } elseif (($resolved + '\').StartsWith($ExpectedRoot, [StringComparison]::OrdinalIgnoreCase) -and (Test-Path -LiteralPath $resolved)) {
     Remove-TestRootWithRetry $resolved
   }

--- a/scripts/test-previous-version-upgrade.ps1
+++ b/scripts/test-previous-version-upgrade.ps1
@@ -37,6 +37,7 @@ $ExternalData = Join-Path $TestRoot "user-owned-external"
 $PreviousInstaller = Join-Path $TestRoot $Baseline.installer.name
 $ExpectedRoot = [System.IO.Path]::GetFullPath($TestRoot).TrimEnd('\') + '\'
 $oldWorkspaceVariable = $env:LLAMA_CPP_WINDOWS_MANAGER_WORKSPACE
+$upgradeFailed = $false
 
 function Invoke-CheckedProcess {
   param([string] $FilePath, [string[]] $ArgumentList, [string] $Label, [string] $LogPath = "")
@@ -173,9 +174,10 @@ try {
   $actualHash = (Get-FileHash -LiteralPath $PreviousInstaller -Algorithm SHA256).Hash.ToLowerInvariant()
   if ($actualHash -ne $Baseline.installer.sha256) { throw "Pinned previous installer hash mismatch." }
 
-  $installLog = Join-Path $TestRoot "installer.log"
-  $installArgs = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/TASKS=", "/DIR=`"$InstallDir`"", "/LOG=`"$installLog`"", "/LOGCLOSEAPPLICATIONS")
-  Invoke-CheckedProcess $PreviousInstaller $installArgs "Previous-version install" $installLog
+  $previousInstallLog = Join-Path $TestRoot "previous-install.log"
+  $candidateInstallLog = Join-Path $TestRoot "candidate-install.log"
+  $installArgs = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/TASKS=", "/DIR=`"$InstallDir`"", "/LOGCLOSEAPPLICATIONS")
+  Invoke-CheckedProcess $PreviousInstaller ($installArgs + "/LOG=`"$previousInstallLog`"") "Previous-version install" $previousInstallLog
   $previousApp = Join-Path $InstallDir "LlamaCppWindowsManager.exe"
   $previousCli = Join-Path $InstallDir "llwmctl.exe"
   $env:LLAMA_CPP_WINDOWS_MANAGER_WORKSPACE = $Workspace
@@ -191,7 +193,7 @@ try {
 
   Set-Content -LiteralPath (Join-Path $Workspace "upgrade-preserve.canary") -Value "preserve" -Encoding ascii
   Set-Content -LiteralPath (Join-Path $ExternalData "external-preserve.canary") -Value "external" -Encoding ascii
-  Invoke-CheckedProcess $Candidate $installArgs "Candidate upgrade install" $installLog
+  Invoke-CheckedProcess $Candidate ($installArgs + "/LOG=`"$candidateInstallLog`"") "Candidate upgrade install" $candidateInstallLog
   if (-not (Test-Path -LiteralPath (Join-Path $Workspace "upgrade-preserve.canary"))) { throw "Upgrade removed workspace state." }
   if (-not (Test-Path -LiteralPath (Join-Path $ExternalData "external-preserve.canary"))) { throw "Upgrade removed external user data." }
 
@@ -218,6 +220,22 @@ try {
   if (-not (Test-Path -LiteralPath (Join-Path $ExternalData "external-preserve.canary"))) { throw "Uninstall removed external user data." }
   Write-Host "Pinned $($Baseline.tag) to candidate installer upgrade validation passed." -ForegroundColor Green
 }
+catch {
+  $upgradeFailed = $true
+  Write-Host "Installer upgrade failed before cleanup: $($_.Exception.Message)"
+  Write-Host $_.ScriptStackTrace
+  $diagnosticRoot = Join-Path $RepoRoot "TestResults/installer-upgrade"
+  $upgradeError = $_
+  try {
+    New-Item -ItemType Directory -Path $diagnosticRoot -Force | Out-Null
+    $upgradeError | Out-String | Set-Content -LiteralPath (Join-Path $diagnosticRoot "failure.txt")
+    Get-ChildItem -LiteralPath $TestRoot -Filter *.log -File -ErrorAction SilentlyContinue |
+      Copy-Item -Destination $diagnosticRoot -ErrorAction Continue
+  } catch {
+    Write-Warning "Could not save installer diagnostics: $($_.Exception.Message)"
+  }
+  throw $upgradeError
+}
 finally {
   $env:LLAMA_CPP_WINDOWS_MANAGER_WORKSPACE = $oldWorkspaceVariable
   Stop-IsolatedManagers
@@ -232,8 +250,8 @@ finally {
     }
   }
   $resolved = [System.IO.Path]::GetFullPath($TestRoot)
-  if ($cleanupUninstallFailed) {
-    Write-Warning "Preserving the temporary upgrade-test root so its uninstaller remains available: $resolved"
+  if ($cleanupUninstallFailed -or $upgradeFailed) {
+    Write-Warning "Preserving the failed upgrade-test root and diagnostics: $resolved"
   } elseif (($resolved + '\').StartsWith($ExpectedRoot, [StringComparison]::OrdinalIgnoreCase) -and (Test-Path -LiteralPath $resolved)) {
     Remove-TestRootWithRetry $resolved
   }

--- a/scripts/test-previous-version-upgrade.ps1
+++ b/scripts/test-previous-version-upgrade.ps1
@@ -193,7 +193,15 @@ try {
 
   Set-Content -LiteralPath (Join-Path $Workspace "upgrade-preserve.canary") -Value "preserve" -Encoding ascii
   Set-Content -LiteralPath (Join-Path $ExternalData "external-preserve.canary") -Value "external" -Encoding ascii
-  Invoke-CheckedProcess $Candidate ($installArgs + "/LOG=`"$candidateInstallLog`"") "Candidate upgrade install" $candidateInstallLog
+  $candidateArgs = $installArgs + "/LOG=`"$candidateInstallLog`""
+  if ($env:GITHUB_ACTIONS -eq "true") {
+    # Restart Manager can identify the hosted runner's provjobd.exe as a file user.
+    # Closing that infrastructure process disconnects the job. The Manager was
+    # explicitly shut down above; still reject locked files or a deferred upgrade.
+    Write-Host "Preserving GitHub runner processes during the already-stopped Manager upgrade."
+    $candidateArgs += @("/NOCLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS", "/RESTARTEXITCODE=3010")
+  }
+  Invoke-CheckedProcess $Candidate $candidateArgs "Candidate upgrade install" $candidateInstallLog
   if (-not (Test-Path -LiteralPath (Join-Path $Workspace "upgrade-preserve.canary"))) { throw "Upgrade removed workspace state." }
   if (-not (Test-Path -LiteralPath (Join-Path $ExternalData "external-preserve.canary"))) { throw "Upgrade removed external user data." }
 


### PR DESCRIPTION
- Stop the installer upgrade check from closing GitHub's runner processes.
- Keep separate installer logs and show failures before cleanup.
- Save failed upgrade logs for investigation.

The failing run identified `provjobd.exe` in Windows Restart Manager, then stopped reporting immediately after the installer shut down file users. On GitHub Actions, the test now preserves other processes after shutting down the Manager through its control API. It still checks the new version, saved settings, restart and uninstall, and rejects upgrades that require a reboot. Normal installer behavior is unchanged.

Checks: full CI passed with all 987 application tests, installer install/repair/uninstall, v2.6 upgrade with saved settings and restart, and portable EXE replacement. CodeQL and dependency review passed.

