### PR TITLE
Keep installer repair checks from closing the GitHub runner

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -114,9 +114,10 @@ publish-only gate is safe beside an installed Manager:
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -IncludePublish
 ```
 
-On GitHub Actions, the previous-version upgrade test shuts the Manager down
-through its control API, then prevents Inno Setup from closing or restarting
-other processes. Windows Restart Manager can identify the hosted runner's
+On GitHub Actions, installer smoke and previous-version upgrade tests prevent
+Inno Setup from closing or restarting other processes. The upgrade test shuts
+the Manager down through its control API first; the smoke test only runs the
+sidecar bootstrap and waits for it to exit. Windows Restart Manager can identify the hosted runner's
 `provjobd.exe` as using the installed files; closing it disconnects the job.
 The test still rejects failed or reboot-deferred upgrades and verifies the new
 version, saved settings, restart, and uninstall. Normal installer behavior and

--- a/scripts/test-installer-smoke.ps1
+++ b/scripts/test-installer-smoke.ps1
@@ -125,6 +125,13 @@ try {
   Assert-NoExistingInstallerIdentity
   Assert-TrustedSignature -Path $Installer -Label "Installer"
   New-Item -ItemType Directory -Path $SmokeRoot -Force | Out-Null
+  $runnerArgs = @()
+  if ($env:GITHUB_ACTIONS -eq "true") {
+    # A completed sidecar bootstrap can leave provjobd.exe visible to Restart
+    # Manager. Preserve hosted runner processes during both install and repair.
+    Write-Host "Preserving GitHub runner processes during installer smoke checks."
+    $runnerArgs = @("/NOCLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS", "/RESTARTEXITCODE=3010")
+  }
   $installArgs = @(
     "/VERYSILENT",
     "/SUPPRESSMSGBOXES",
@@ -133,7 +140,7 @@ try {
     "/DIR=`"$InstallDir`"",
     "/LOG=`"$InstallLog`""
   )
-  Invoke-CheckedProcess -FilePath $Installer -ArgumentList $installArgs -Label "Silent clean install"
+  Invoke-CheckedProcess -FilePath $Installer -ArgumentList ($installArgs + $runnerArgs) -Label "Silent clean install"
   Assert-InstalledFiles
   Assert-TrustedSignature -Path (Join-Path $InstallDir "LlamaCppWindowsManager.exe") -Label "Installed application"
   Assert-TrustedSignature -Path (Join-Path $InstallDir "llwmctl.exe") -Label "Installed control CLI"
@@ -154,7 +161,7 @@ try {
     "/DIR=`"$InstallDir`"",
     "/LOG=`"$RepairLog`""
   )
-  Invoke-CheckedProcess -FilePath $Installer -ArgumentList $repairArgs -Label "Silent repair install"
+  Invoke-CheckedProcess -FilePath $Installer -ArgumentList ($repairArgs + $runnerArgs) -Label "Silent repair install"
   Assert-InstalledFiles
   Assert-TrustedSignature -Path (Join-Path $InstallDir "LlamaCppWindowsManager.exe") -Label "Repaired application"
   Assert-TrustedSignature -Path (Join-Path $InstallDir "llwmctl.exe") -Label "Repaired control CLI"


### PR DESCRIPTION
- Apply the GitHub runner protection to fresh-install and repair checks too.
- Keep the normal installer behavior and local test behavior unchanged.
- Continue to reject failed installs and installs that need a reboot.

The separate main-branch run stopped reporting during repair after sidecar bootstrap. This extends the upgrade-test fix to both installer smoke invocations, so Restart Manager cannot close the hosted runner there either.

Checks: full Windows CI passed, including all 987 application tests, install, repair, uninstall, v2.6 upgrade and portable replacement. CodeQL and dependency review passed.

