### PR TITLE
Fix draft verification and release download ordering

### DIFF
--- a/docs/UNSIGNED_RELEASE.md
+++ b/docs/UNSIGNED_RELEASE.md
@@ -24,15 +24,20 @@ manual GitHub publication. Keep `TRUSTED_RELEASE_ENABLED` unset. Do not pass
 
 For v2.7.0, the release assets are exactly:
 
-- `LlamaCppWindowsManager-Setup-2.7.0-win-x64.exe`
-- `LlamaCppWindowsManager-Setup-2.7.0-win-x64.exe.sha256`
+- `Setup-LlamaCppWindowsManager-2.7.0-win-x64.exe`
+- `Setup-LlamaCppWindowsManager-2.7.0-win-x64.exe.sha256`
 - `LlamaCppWindowsManager.exe`
 - `LlamaCppWindowsManager.exe.sha256`
 
-The portable EXE is uploaded first. Older v1.0/v1.1 clients can select the first
-EXE when their legacy filename is missing; the publisher refuses to proceed if
-GitHub returns the installer first. This prevents the known asset-selection error
-but does not certify every historical installation path.
+GitHub sorts release assets by filename, regardless of upload order. Staging
+names the public installer with a `Setup-` prefix so the portable EXE sorts first;
+the local build output keeps its existing name. Older v1.0/v1.1 clients can select
+the first EXE when their legacy filename is missing, and the publisher verifies
+the returned order before publication. This prevents the known asset-selection
+error but does not certify every historical installation path.
+
+Draft verification resolves the numeric release ID from the authenticated release
+list. GitHub's by-tag REST endpoint does not resolve unpublished drafts.
 
 The workflow artifact may be transported by GitHub as a ZIP; that transport
 container is not a portable product download and must not be attached to the

--- a/scripts/publish-unsigned-release.ps1
+++ b/scripts/publish-unsigned-release.ps1
@@ -21,9 +21,10 @@ $tagCommit = & git -C $repoRoot rev-parse "$Tag^{commit}"
 if ($LASTEXITCODE -ne 0 -or $tagCommit -ne $headCommit) { throw "Release tag must identify the checked-out, validated commit." }
 
 # v1.0/v1.1 clients fall back to the first EXE when the old filename is absent.
-# Upload the portable EXE first and verify GitHub's returned asset order before publication.
+# GitHub sorts assets by filename; the Setup- prefix keeps the portable EXE first.
+# Verify the returned order as well as the uploaded bytes before publication.
 $names = @("LlamaCppWindowsManager.exe", "LlamaCppWindowsManager.exe.sha256",
-  "LlamaCppWindowsManager-Setup-$version-win-x64.exe", "LlamaCppWindowsManager-Setup-$version-win-x64.exe.sha256")
+  "Setup-LlamaCppWindowsManager-$version-win-x64.exe", "Setup-LlamaCppWindowsManager-$version-win-x64.exe.sha256")
 $files = @($names | ForEach-Object { Join-Path ([IO.Path]::GetFullPath($AssetDirectory)) $_ })
 foreach ($file in $files) {
   if (-not (Test-Path -LiteralPath $file -PathType Leaf)) { throw "Missing release asset: $file" }
@@ -35,10 +36,10 @@ foreach ($file in @($files[0], $files[2])) {
 }
 $productVersion = (Get-Item -LiteralPath $files[0]).VersionInfo.ProductVersion.Trim()
 if ($productVersion -ne "$Tag+$headCommit") { throw "Portable EXE must be built from tagged commit $headCommit; found $productVersion." }
-$releasesJson = & gh release list --repo $repository --limit 100 --json tagName,isDraft
+$releasesJson = & gh api "repos/$repository/releases?per_page=100"
 if ($LASTEXITCODE -ne 0) { throw "Could not read GitHub releases." }
-$existing = @($releasesJson | ConvertFrom-Json | Where-Object { $_.tagName -eq $Tag })
-if ($existing.Count -gt 0 -and -not $existing[0].isDraft) { throw "Release is already published; never replace its assets." }
+$existing = @($releasesJson | ConvertFrom-Json | Where-Object { $_.tag_name -eq $Tag })
+if ($existing.Count -gt 0 -and -not $existing[0].draft) { throw "Release is already published; never replace its assets." }
 if ($existing.Count -eq 0) {
   & gh release create $Tag --repo $repository --verify-tag --draft --title "llama.cpp Windows Manager $Tag" --notes-file $notes
   if ($LASTEXITCODE -ne 0) { throw "Could not create release draft." }
@@ -47,7 +48,13 @@ if ($existing.Count -eq 0) {
     if ($LASTEXITCODE -ne 0) { throw "Asset upload failed; draft remains unpublished." }
   }
 }
-$releaseJson = & gh api "repos/$repository/releases/tags/$Tag"
+# The by-tag REST endpoint does not resolve unpublished drafts. Find the draft
+# in the authenticated release list, then verify it through its numeric ID.
+$draftsJson = & gh api "repos/$repository/releases?per_page=100"
+if ($LASTEXITCODE -ne 0) { throw "Could not locate the release draft." }
+$drafts = @($draftsJson | ConvertFrom-Json | Where-Object { $_.tag_name -eq $Tag -and $_.draft })
+if ($drafts.Count -ne 1) { throw "Expected exactly one unpublished release draft for $Tag." }
+$releaseJson = & gh api "repos/$repository/releases/$($drafts[0].id)"
 if ($LASTEXITCODE -ne 0) { throw "Could not verify the draft assets." }
 $release = $releaseJson | ConvertFrom-Json
 if (-not $release.draft -or $release.assets.Count -ne 4) { throw "Expected an unpublished draft containing exactly four assets." }

--- a/scripts/stage-unsigned-release.ps1
+++ b/scripts/stage-unsigned-release.ps1
@@ -28,9 +28,16 @@ foreach ($file in @($app, $installer)) {
   }
 }
 New-Item -ItemType Directory -Path $output | Out-Null
-foreach ($file in @($app, "$app.sha256", $installer, "$installer.sha256")) {
+foreach ($file in @($app, "$app.sha256")) {
   Copy-Item -LiteralPath $file -Destination $output
 }
+# GitHub sorts release assets by name. Keep the portable EXE ahead of the
+# installer for old clients that fall back to the first executable.
+$publicInstallerName = "Setup-LlamaCppWindowsManager-$version-win-x64.exe"
+$publicInstaller = Join-Path $output $publicInstallerName
+Copy-Item -LiteralPath $installer -Destination $publicInstaller
+$installerHash = (Get-FileHash -LiteralPath $publicInstaller -Algorithm SHA256).Hash.ToLowerInvariant()
+[IO.File]::WriteAllText("$publicInstaller.sha256", "$installerHash  $publicInstallerName`n", [Text.UTF8Encoding]::new($false))
 Write-Host "Staged four unsigned release assets in $output" -ForegroundColor Green
 Write-Host "Release notes: $notes"
 Write-Host "Staging does not publish or certify validation. Review the release gate and upgrade results before upload."


### PR DESCRIPTION
- Look up release drafts by their ID so GitHub can return them before publication.
- Name the public installer with a Setup- prefix so old updaters select the portable EXE first.
- Write the checksum using the public filename and document the release process.

GitHub sorts assets by filename even when the portable EXE is uploaded first. The v2.7.0 release was published with the corrected names and all four uploaded files verified; these changes make the helpers follow the same process next time.

Checks: staging reproduces all four verified public release files byte for byte. Full CI passed with all 987 application tests, installer and update checks, CodeQL and dependency review. PowerShell syntax and documentation validation also pass. Published binaries and the v2.7.0 tag remain unchanged.

