### PR TITLE
Use focused issue PRs and validate releases together

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,36 @@
+## Related issue and dependencies
+
+Closes #<primary-issue> (use a reference instead if this is a partial contribution).
+List prerequisite PRs and their merge order, or write "None". For a release PR,
+link its release-planning issue and the included issue PRs or milestone.
+
 ## What changed
 
 Describe the user-visible behavior and the reason for the change.
 
 ## Risk and compatibility
 
-List affected areas such as models, profiles, groups, runtimes, sessions,
-gateway, control API, persistence, packaging, or localization.
+List affected shared contracts such as saved profiles/settings, database
+migrations, model/runtime behavior, gateway/control APIs, packaging, or
+localization. Explain compatibility with current `main` and related changes,
+including combined-behavior tests and any user migration. For a large coherent
+change, explain why it stays in one PR and how to review it.
 
 ## Validation
 
-- [ ] Relevant behavioral tests were added or updated.
+- [ ] This PR addresses one primary issue; unrelated work has separate PRs.
+- [ ] Dependencies are merged and this PR is up to date with `main` before merge.
+- [ ] Relevant behavioral and integration tests were added or updated, or are not applicable (explain).
 - [ ] `scripts/test-release-gate.ps1` passes, or the omitted step is explained.
 - [ ] UI behavior was checked at the default window size when applicable.
 - [ ] Documentation and in-app Help were updated when behavior changed.
 - [ ] No generated output, workspace data, models, runtimes, logs, or secrets are included.
 - [ ] Public artifacts are not described as signed without a verified signature.
+
+## Release notes
+
+Link `docs/releases/unreleased/<issue>.md`, or explain why no user-facing entry
+is needed. Release PRs collect completed entries into the versioned notes.
 
 ## Manual checks still required
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,13 @@ if ($actual -ne $expected) { throw "Release checksum mismatch: $asset" }
 The canonical source repository is
 [github.com/alekk89/llama-cpp-windows-manager](https://github.com/alekk89/llama-cpp-windows-manager).
 
+For repository contributions, follow the issue-per-PR, compatibility, and
+release-note rules in `CONTRIBUTING.md`, and the release-planning rules in
+`docs/REPOSITORY_GOVERNANCE.md`. Read these in the source checkout before editing;
+in a packaged installation, use the canonical repository for these contributor
+documents. Keep unrelated issues in separate PRs; large releases collect
+completed PRs without changing that contribution rule.
+
 For repository changes, read `docs/DEVELOPMENT.md` and, for architectural work,
 `docs/ARCHITECTURE.md`. Preserve existing worktree changes and generated-data
 boundaries. Run tests proportional to the change and the full gate for control,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,60 @@ Use a feature branch. Preserve unrelated worktree changes and never commit
 models, runtimes, databases, logs, credentials, generated workspaces, `bin`,
 `obj`, `TestResults`, or `dist`.
 
+## Issues and pull requests
+
+Use one focused branch and pull request per issue or feature. Link the primary
+GitHub issue in the PR; create an issue first when the work has no existing one.
+Keep the implementation, relevant tests, documentation, and release-note entry
+for that issue together. Do not bundle unrelated fixes or features because they
+are intended for the same release. These rules apply to maintainers and coding
+agents as well as external contributors.
+
+A large release can contain any number of completed issue PRs. For a substantial
+feature, use a tracking issue and split independently reviewable work into linked
+child issues and PRs where practical. A larger PR is appropriate when one coherent
+change cannot safely be split; explain why and provide a review and validation
+plan. There is no arbitrary line-count or release-size limit.
+
+Each PR should state the problem, resulting behavior, compatibility risks, and
+actual validation performed. Use `Closes #<issue>` only when the issue's acceptance
+criteria are met; use a reference for a partial contribution. Dependency links
+must name the prerequisite PRs and intended merge order. Do not merge a dependent
+PR until its prerequisites are merged and it has been checked against `main`.
+
+## Compatibility before merge
+
+Keep `main` usable. Before merging, update the PR with the latest `main`, resolve
+conflicts deliberately, and rerun required checks. The strict up-to-date branch
+requirement in [Repository governance](docs/REPOSITORY_GOVERNANCE.md) enforces this:
+when another PR merges, the next PR must update and pass again. Do not bypass the
+checks or force-push `main`. Passing separate checks on stale branches does not
+establish that the combined changes work.
+
+Identify shared contracts in the PR: settings and saved profiles, database
+migrations, control/API responses, gateway behavior, runtime arguments, and
+installer/update behavior. When two changes interact, add or update behavioral
+integration tests covering their combined behavior. Preserve existing user data
+and supported clients, or explicitly document and test the migration. Resolving
+text conflicts alone is not a compatibility check.
+
+Record hardware, WSL, UI, or other manual checks that CI cannot establish. A
+failed or intermittent check needs diagnosis and useful logs; do not repeatedly
+rerun it solely to obtain a green result. Unfinished or incompatible work stays
+on its branch until it can be integrated safely.
+
+## Release-note entries
+
+For user-facing changes, add a short bullet to a file named after the issue in
+[docs/releases/unreleased](docs/releases/unreleased/README.md), for example
+`51.md`. Describe the behavior users gain or the problem fixed. Include any
+upgrade or compatibility action users need to take. Docs-only or internal changes
+may omit the entry; explain why in the PR. Do not bump the app version in each
+feature PR or rewrite notes for an already published release.
+
+Release scope, cadence, and final combined validation are defined in
+[Repository governance](docs/REPOSITORY_GOVERNANCE.md#release-planning).
+
 ## Change guidelines
 
 - Keep `MainWindow` as shell coordination; put behavior in the appropriate

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,6 +64,14 @@ presenters, dialogs, tray notifications, and page factories resolve user-facing
 text with `Loc.T`. Add new English keys first and let incomplete language packs
 use the deliberate English fallback until a real translation is available.
 
+## Contribution and release process
+
+Follow [CONTRIBUTING.md](../CONTRIBUTING.md#issues-and-pull-requests) for focused
+issue PRs, dependency handling, compatibility checks, and release-note entries.
+Follow [release planning](REPOSITORY_GOVERNANCE.md#release-planning) to assemble
+completed PRs into a release of any size and validate the final combined build.
+The commands below define the technical checks used by that process.
+
 ## Local Gate
 
 Run these before opening a release PR or after any architecture-level change:

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -27,6 +27,51 @@ bypass, record the reason in an issue. Afterward, open a follow-up pull request,
 run every omitted check, and link the successful run from the issue. Never use a
 bypass for routine feature delivery or to avoid a failing test.
 
+## Release planning
+
+[CONTRIBUTING.md](../CONTRIBUTING.md#issues-and-pull-requests) owns the issue and
+PR-scope rules. Release size is independent of PR size: a release may include
+many features, major improvements, or coordinated changes delivered through
+separate issue PRs.
+
+1. Review release readiness roughly weekly. This is a planning rhythm, not an
+   automatic publishing schedule or deadline: release sooner for an urgent fix,
+   or allow more time for a larger update. Never include unfinished work merely
+   to meet a date.
+2. Use a release-planning issue or milestone to list the intended issue PRs,
+   dependencies, compatibility/migration risks, and manual validation needed.
+   Merge compatible, completed PRs through the normal protected-main checks.
+   A candidate includes every change in its commit history; a milestone does not
+   exclude other changes already merged into `main`. Keep work that must wait
+   on its branch until the appropriate release cycle.
+3. Open a focused release PR linked to the planning issue. Set the version,
+   collect the completed entries from `docs/releases/unreleased` into
+   `docs/releases/v<version>.md`, and update release-specific metadata or baseline
+   expectations when needed. Remove only the entries included in those notes;
+   retain the unreleased directory's README. Keep unrelated implementation out
+   of the release PR.
+4. Select the exact merged commit as the release candidate. Validate the combined
+   application, build its release binaries once, and run the full release gate
+   plus installer lifecycle, pinned-version upgrade, and portable-update checks
+   on those binaries. Complete the recorded manual checks. Independent PR checks
+   do not replace this combined validation.
+5. If validation finds a defect, record it in an issue and fix it through a
+   focused PR. Select a new candidate and rebuild/revalidate its affected paths
+   and required release gates. An unresolved flaky check is a failure to
+   investigate, not a reason to skip the gate. Do not add unrelated features to
+   a candidate being prepared for publication.
+6. Publish only the exact artifacts validated for the selected commit, following
+   the appropriate publication procedure below. Verify draft asset names,
+   download selection, checksums, source version, and notes before publication.
+   An interrupted upload must reconcile the draft against those same verified
+   files before continuing; never blindly publish or rebuild under the same tag.
+   Record the successful checks and final commit in the release-planning issue.
+
+Current CI runs its required build, tests, quality, and packaging checks for every
+PR. The release preparation workflow additionally validates and stages the final
+combined artifacts. This policy does not introduce skipped checks or a new CI
+speed tier. Changes to the checks themselves require their own focused issue PR.
+
 ## Release authority
 
 Unsigned community releases are permitted while signing is unavailable. They

--- a/docs/UNSIGNED_RELEASE.md
+++ b/docs/UNSIGNED_RELEASE.md
@@ -4,10 +4,11 @@ While signing is unavailable, releases use the protected-main PR pipeline and
 manual GitHub publication. Keep `TRUSTED_RELEASE_ENABLED` unset. Do not pass
 `-RequireSigned` or describe the resulting files as signed or publisher-verified.
 
-1. Integrate the intended source and tests, including new files. Finalize the
-   version and short notes in `docs/releases/v<version>.md`.
-2. Run the local source and portable gate. Push the feature branch, open a PR,
-   pass required CI checks, and merge into protected `main`.
+1. Follow [release planning](REPOSITORY_GOVERNANCE.md#release-planning): merge
+   completed issue PRs, then prepare a focused release PR with the version,
+   collected release-note entries, and any release-specific metadata.
+2. Run the local source and portable gate. Pass required checks on the release
+   PR against current `main`, then merge it through branch protection.
 3. Run **Prepare unsigned release** on that exact `main` commit. The workflow
    uses a fresh Windows runner to run the complete release gate, installer
    lifecycle tests, pinned previous-version installer upgrade, and standalone

--- a/docs/releases/unreleased/README.md
+++ b/docs/releases/unreleased/README.md
@@ -1,0 +1,21 @@
+# Unreleased change notes
+
+Add one Markdown file per user-facing issue, named `<issue-number>.md`. Keep the
+entry to short, plain-language bullets describing the behavior change and any
+required upgrade action. Multiple PRs completing the same issue can update its
+entry. Docs-only and internal changes may omit an entry with an explanation in
+the PR.
+
+Example content:
+
+```text
+- Keep saved profiles available when a model file is temporarily missing.
+```
+
+During release preparation, collect entries for completed issues into the
+versioned release notes, then remove only those consumed entries. Keep this
+README and entries for changes not included in that release. Do not change notes
+for an already published release as part of preparing a new one.
+
+See [Contributing](../../../CONTRIBUTING.md#release-note-entries) and
+[release planning](../../REPOSITORY_GOVERNANCE.md#release-planning).


### PR DESCRIPTION
Closes #51

- Use a focused PR for each issue or feature, with its tests, documentation and release-note entry.
- Keep large updates possible by collecting completed PRs, with linked child issues for substantial features where useful.
- Require current-main checks, explicit dependencies and integration tests where changes interact.
- Keep release PRs focused on the version, collected notes and release metadata, then validate the final combined artifacts.
- Point coding agents and contributors to the same process.

Dependencies: None.

Compatibility: documentation and PR-template changes only. Existing protected-main checks remain enabled; no CI checks are skipped or weakened. Release scope does not filter changes already merged into the selected commit.

Validation: all 11 release-repository tests pass, documentation validation passes, and the live main-branch protection has strict up-to-date checks enabled. Full CI runs on this PR.

Release notes: not applicable; this changes the contribution and release process rather than application behavior. No application or manual hardware checks are required for the text change.
