### PR TITLE
Reduce gateway request allocations by preserving payload bytes

### DIFF
--- a/docs/performance/gateway-request-allocations.md
+++ b/docs/performance/gateway-request-allocations.md
@@ -1,0 +1,38 @@
+# Gateway request allocation check
+
+Issue: [#53](https://github.com/alekk89/llama-cpp-windows-manager/issues/53).
+
+Run the reproducible allocation guard with the SDK from `global.json`:
+
+```powershell
+dotnet test --project tests/LocalLlmConsole.Tests --filter-class '*GatewayRequestAllocationTests' --output Detailed
+```
+
+The test reads a 4,194,340-byte JSON body from a synchronous `MemoryStream`,
+rewrites its gateway model name to the runtime alias, and checks the resulting
+JSON. Input construction and output validation are outside the allocation
+measurement. It warms the code and pools before asserting a broad allocation
+budget; elapsed time is deliberately not asserted.
+
+Measured locally on Windows x64 with .NET 10 on 2026-09-04:
+
+| Warm sample | Read allocations | Read plus alias rewrite |
+| --- | ---: | ---: |
+| Before (`e9a1d1f`, isolated audit harness) | 8,470,944 bytes | 21,055,408 bytes |
+| After (regression test) | 4,194,632 bytes | 8,389,576 bytes |
+
+That is approximately 60% less managed allocation for this workload. These are
+per-thread allocated bytes, not peak process memory, latency, or inference
+throughput. The original baseline harness did not include the test assertion
+overhead, so tiny byte differences are not significant.
+
+Known-length reads transfer the stream-owned array only when its length exactly
+matches the received body. Unknown or inaccurate lengths retain bounded buffered
+reading and may require growth or a final copy. The scratch buffer is pooled and
+cleared on return; the returned request body is never a pooled buffer.
+
+Alias forwarding scans JSON and replaces only top-level model values in one
+exact-sized output array. Other request bytes, including whitespace, number
+spellings, nested model fields, and escaped payloads, remain untouched. This
+avoids decoding and re-encoding large prompt strings. The separate model-routing
+lookup still validates/parses the incoming request as before.

--- a/docs/releases/unreleased/53.md
+++ b/docs/releases/unreleased/53.md
@@ -1,0 +1,1 @@
+- Reduce gateway request-buffer allocations for large prompts while preserving request limits and runtime alias forwarding.

--- a/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestBodyReader.cs
+++ b/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestBodyReader.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+
 namespace LocalLlmConsole.Services;
 
 public sealed class ModelGatewayRequestBodyTooLargeException : InvalidOperationException
@@ -33,18 +35,29 @@ public static class ModelGatewayRequestBodyReader
         using var memory = contentLength is > 0 and <= int.MaxValue
             ? new MemoryStream((int)contentLength)
             : new MemoryStream();
-        var buffer = new byte[BufferSize];
-        long total = 0;
-        while (true)
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        try
         {
-            var read = await stream.ReadAsync(buffer, cancellationToken);
-            if (read == 0) break;
-            total += read;
-            if (total > maxBytes)
-                throw new ModelGatewayRequestBodyTooLargeException($"Gateway request body is too large. Limit is {DisplayFormatService.Bytes(maxBytes)}.");
-            await memory.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
-        }
+            long total = 0;
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, BufferSize), cancellationToken);
+                if (read == 0) break;
+                total += read;
+                if (total > maxBytes)
+                    throw new ModelGatewayRequestBodyTooLargeException($"Gateway request body is too large. Limit is {DisplayFormatService.Bytes(maxBytes)}.");
+                memory.Write(buffer, 0, read);
+            }
 
-        return memory.ToArray();
+            // Transfer the stream-owned array when the declared length was exact.
+            // Never expose unused capacity or a pooled array to the caller.
+            if (memory.TryGetBuffer(out var body) && body.Count == body.Array!.Length)
+                return body.Array;
+            return memory.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+        }
     }
 }

--- a/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestResolver.cs
+++ b/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestResolver.cs
@@ -73,22 +73,50 @@ public static class ModelGatewayRequestResolver
     public static byte[] BodyForRuntime(byte[] body, AppSettings launchSettings)
     {
         var aliases = RuntimeModelAliasService.ReadAliases(launchSettings.CustomParameters);
-        if (aliases.Count == 0 || aliases.Contains(ExtractRequestedModel(body), StringComparer.Ordinal)) return body;
+        if (aliases.Count == 0) return body;
 
-        // Gateway suffixes select profiles; llama-server only knows its configured aliases.
-        // Use the active session's settings, which may differ from a subsequently edited profile.
-        using var document = JsonDocument.Parse(body);
-        using var stream = new MemoryStream();
-        using (var writer = new Utf8JsonWriter(stream))
+        // Scan once and replace only top-level model values. Keeping all other
+        // bytes avoids decoding/re-encoding large prompts and multimodal payloads.
+        var reader = new Utf8JsonReader(body);
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Gateway request body must be a JSON object.");
+        var ranges = new List<(int Start, int Length)>();
+        var requestedModel = "";
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
         {
-            writer.WriteStartObject();
-            foreach (var property in document.RootElement.EnumerateObject())
-            {
-                if (property.NameEquals("model")) writer.WriteString("model", aliases[0]);
-                else property.WriteTo(writer);
-            }
-            writer.WriteEndObject();
+            var isModel = reader.ValueTextEquals("model"u8);
+            if (!reader.Read()) throw new JsonException("Missing property value.");
+            var start = checked((int)reader.TokenStartIndex);
+            if (isModel)
+                requestedModel = reader.TokenType == JsonTokenType.String ? reader.GetString()?.Trim() ?? "" : "";
+            reader.Skip();
+            if (isModel) ranges.Add((start, checked((int)reader.BytesConsumed) - start));
         }
-        return stream.ToArray();
+        if (reader.TokenType != JsonTokenType.EndObject)
+            throw new JsonException("Incomplete gateway request body.");
+        // Validate trailing input even when the runtime already accepts the alias.
+        if (reader.Read()) throw new JsonException("Unexpected trailing JSON value.");
+        if (ranges.Count == 0 || aliases.Contains(requestedModel, StringComparer.Ordinal)) return body;
+
+        // Gateway suffixes select profiles; use the active session's alias, which
+        // may differ from a subsequently edited saved profile.
+        var replacement = JsonSerializer.SerializeToUtf8Bytes(aliases[0]);
+        var length = body.Length;
+        foreach (var range in ranges)
+            length = checked(length - range.Length + replacement.Length);
+        var rewritten = new byte[length];
+        var sourceOffset = 0;
+        var destinationOffset = 0;
+        foreach (var range in ranges)
+        {
+            var unchanged = range.Start - sourceOffset;
+            body.AsSpan(sourceOffset, unchanged).CopyTo(rewritten.AsSpan(destinationOffset));
+            destinationOffset += unchanged;
+            replacement.CopyTo(rewritten.AsSpan(destinationOffset));
+            destinationOffset += replacement.Length;
+            sourceOffset = range.Start + range.Length;
+        }
+        body.AsSpan(sourceOffset).CopyTo(rewritten.AsSpan(destinationOffset));
+        return rewritten;
     }
 }

--- a/tests/LocalLlmConsole.Tests/Gateway/GatewayRequestAllocation.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Gateway/GatewayRequestAllocation.Tests.cs
@@ -1,0 +1,107 @@
+using System.Text;
+using System.Text.Json;
+using LocalLlmConsole.Models;
+using LocalLlmConsole.Services;
+
+namespace LocalLlmConsole.Tests;
+
+public sealed class GatewayRequestAllocationTests : ManagerRegressionTestBase
+{
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(20)]
+    public async Task ShortReadsAndInaccurateLengthsReturnOnlyReceivedBytes(long declaredLength)
+    {
+        byte[] expected = [1, 2, 3, 4, 5, 6, 7];
+        using var stream = new ShortReadStream(expected);
+        var actual = await ModelGatewayRequestBodyReader.ReadBodyBufferAsync(
+            stream, declaredLength, 20, TestContext.Current.CancellationToken);
+        Assert.Equal(expected, actual);
+        // Subsequent pooled-buffer reuse must not mutate a previously returned body.
+        using var second = new MemoryStream(new byte[100_000]);
+        await ModelGatewayRequestBodyReader.ReadBodyBufferAsync(second, second.Length, second.Length, TestContext.Current.CancellationToken);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task ExcessInputStillChecksTheActualLimitAndCancellation()
+    {
+        using var stream = new ShortReadStream(new byte[8]);
+        await Assert.ThrowsAsync<ModelGatewayRequestBodyTooLargeException>(() =>
+            ModelGatewayRequestBodyReader.ReadBodyBufferAsync(stream, 3, 7, TestContext.Current.CancellationToken));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var empty = new MemoryStream();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ModelGatewayRequestBodyReader.ReadBodyBufferAsync(empty, 0, 7, cancellation.Token));
+    }
+
+    [Fact]
+    public void AliasRewritePreservesDuplicatePropertiesAndEscapedContent()
+    {
+        var settings = AppSettings.CreateDefault(CreateTempRoot()) with { CustomParameters = "--alias runtime" };
+        var body = Encoding.UTF8.GetBytes("""{"model":"first","nested":{"model":"inner"},"model":"last","prompt":"\u263a\n\""}""");
+        using var result = JsonDocument.Parse(ModelGatewayRequestResolver.BodyForRuntime(body, settings));
+        Assert.Equal(2, result.RootElement.EnumerateObject().Count(p => p.Name == "model" && p.Value.GetString() == "runtime"));
+        Assert.Equal("inner", result.RootElement.GetProperty("nested").GetProperty("model").GetString());
+        Assert.Equal("☺\n\"", result.RootElement.GetProperty("prompt").GetString());
+    }
+
+    [Fact]
+    public async Task LargeKnownLengthRequestHasBoundedWarmAllocations()
+    {
+        var settings = AppSettings.CreateDefault(CreateTempRoot()) with { CustomParameters = "--alias runtime-name" };
+        var payload = Encoding.UTF8.GetBytes("{\"model\":\"gateway-name\",\"prompt\":\"" + new string('x', 4 * 1024 * 1024) + "\"}");
+        long allocated = 0;
+        for (var sample = 0; sample < 3; sample++)
+        {
+            using var input = new MemoryStream(payload);
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            // MemoryStream completes synchronously, so the counter stays on this thread.
+            var pending = ModelGatewayRequestBodyReader.ReadBodyBufferAsync(input, input.Length, 64L * 1024 * 1024, TestContext.Current.CancellationToken);
+            Assert.True(pending.IsCompletedSuccessfully);
+            var read = await pending;
+            var afterRead = GC.GetAllocatedBytesForCurrentThread();
+            var rewritten = ModelGatewayRequestResolver.BodyForRuntime(read, settings);
+            allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            TestContext.Current.TestOutputHelper!.WriteLine($"Sample {sample}: input={payload.Length}, read={afterRead - before}, total={allocated} bytes");
+            using var document = JsonDocument.Parse(rewritten);
+            Assert.Equal("runtime-name", document.RootElement.GetProperty("model").GetString());
+            Assert.Equal(4 * 1024 * 1024, document.RootElement.GetProperty("prompt").GetString()!.Length);
+        }
+        // A broad allocation budget catches reintroduced whole-body copies; this is
+        // not a timing assertion or a claim about peak memory or runtime throughput.
+        Assert.True(allocated < payload.Length * 4L, $"Warm request allocated {allocated} bytes.");
+    }
+
+    [Theory]
+    [InlineData("{\"model\":\"runtime\",\"prompt\":[}")]
+    [InlineData("{\"model\":\"runtime\"} {}")]
+    [InlineData("{\"model\":\"runtime\"")]
+    [InlineData("[]")]
+    public void AliasForwardingRejectsMalformedJsonEvenForAnAcceptedAlias(string json)
+    {
+        var settings = AppSettings.CreateDefault(CreateTempRoot()) with { CustomParameters = "--alias runtime" };
+        Assert.ThrowsAny<JsonException>(() => ModelGatewayRequestResolver.BodyForRuntime(Encoding.UTF8.GetBytes(json), settings));
+    }
+
+    [Fact]
+    public void EscapedModelPropertyAndLongAliasPreserveOtherBytesExactly()
+    {
+        var alias = new string('x', 1000);
+        var settings = AppSettings.CreateDefault(CreateTempRoot()) with { CustomParameters = "--alias " + alias };
+        const string suffix = ", \"number\": 1.00e+02, \"prompt\": \"\\u263a\" }  ";
+        var body = Encoding.UTF8.GetBytes("{ \"mo\\u0064el\": \"short\"" + suffix);
+        var rewritten = Encoding.UTF8.GetString(ModelGatewayRequestResolver.BodyForRuntime(body, settings));
+        Assert.Equal("{ \"mo\\u0064el\": \"" + alias + "\"" + suffix, rewritten);
+    }
+
+    private sealed class ShortReadStream(byte[] body) : MemoryStream(body)
+    {
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => base.ReadAsync(buffer[..Math.Min(2, buffer.Length)], cancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #53. Dependencies: none.

A 4 MiB gateway JSON request previously allocated about 20 MiB while reading and forwarding its runtime alias. Known-length reads now transfer their exact-sized owned buffer, and alias forwarding replaces only top-level model values while preserving the rest of the payload byte for byte. The temporary read buffer is pooled and cleared on return.

Measured warm allocations for the same synthetic request fell from 21,055,408 to 8,389,576 bytes (about 60%). This is allocation volume, not peak memory or inference throughput. The methodology and reproducible regression command are in docs/performance/gateway-request-allocations.md.

Request-size limits, cancellation, unknown/inaccurate lengths, nested fields, duplicate model properties, escaped names, and active-session alias selection remain covered. Malformed JSON is rejected; no API, profile, or database migration is introduced.

Validation: full local release gate passed (946 regression tests plus 54 WPF tests; no failures/skips; service coverage 84.4%, model/view-model coverage 97.7%). Release build, formatting, code-shape, docs, whitespace, and package audit passed. Gateway behavioral tests and the allocation guard pass. Live production sessions were not used; no new manual UI check is required for this transport-only change. GitHub checks run on this PR.

Release note: docs/releases/unreleased/53.md.

Combined validation: all three PR heads (#55, #57, #58) were applied together on a temporary local branch from main at e9a1d1f. They combined without conflicts and passed the full release gate: 956 regression tests plus 54 WPF tests (1,010 total), no failures/skips, and all quality/package checks. This does not replace updating each remaining PR against main and rerunning required checks after a merge.
