### PR TITLE
Cache gateway routes with write-driven invalidation and indexed lookup

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,14 @@ Current:
     same-model replacement is an explicit launch-preparation choice; automated
     and group loads do not apply that UI preference.
 
+Gateway route catalogs are immutable snapshots indexed by the existing alias,
+legacy ID, name, profile ID, and filename lookup precedence. `StateStore` advances
+a catalog revision under its database gate before model/profile writes, including
+legacy repairs. Catalog readers reuse an unchanged revision and retry construction
+if a write overlaps the model/profile reads or default repair. Add invalidation
+when introducing another catalog write path. Running sessions remain live reads;
+the route cache does not change admission or lifecycle policy.
+
 ## Architecture Contract
 
 Finished architecture means a feature can be changed through its feature module,

--- a/docs/releases/unreleased/54.md
+++ b/docs/releases/unreleased/54.md
@@ -1,0 +1,1 @@
+- Reuse the gateway routing catalog between model and profile changes, reducing repeated database reads and route lookup work.

--- a/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestResolver.cs
+++ b/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRequestResolver.cs
@@ -44,6 +44,7 @@ public static class ModelGatewayRequestResolver
     {
         var requested = (requestedModel ?? "").Trim();
         if (string.IsNullOrWhiteSpace(requested)) return null;
+        if (models is ModelGatewayRouteSnapshot snapshot) return snapshot.Resolve(requested);
 
         var exact = models.FirstOrDefault(route => string.Equals(route.Id, requested, StringComparison.OrdinalIgnoreCase))
             ?? models.FirstOrDefault(route => string.Equals(route.LegacyId, requested, StringComparison.OrdinalIgnoreCase))

--- a/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRouteSnapshot.cs
+++ b/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRouteSnapshot.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+
+namespace LocalLlmConsole.Services;
+
+/// <summary>A detached catalog with the same lookup precedence as the legacy resolver.</summary>
+public sealed class ModelGatewayRouteSnapshot : IReadOnlyList<ModelGatewayModelRoute>
+{
+    private readonly ModelGatewayModelRoute[] _routes;
+    private readonly Dictionary<string, ModelGatewayModelRoute> _lookup = new(StringComparer.OrdinalIgnoreCase);
+
+    public ModelGatewayRouteSnapshot(IReadOnlyList<ModelGatewayModelRoute> routes)
+    {
+        _routes = routes.ToArray();
+        // Priority applies across the entire list, not within each individual route.
+        AddKeys(route => route.Id);
+        AddKeys(route => route.LegacyId);
+        AddKeys(route => route.Name);
+        AddKeys(route => route.Profile.Id);
+        AddKeys(route => route.Profile.IsDefault ? route.Model.Name : null);
+        AddKeys(route => route.Profile.IsDefault ? Path.GetFileName(route.Model.ModelPath) : null);
+        AddKeys(route => route.Profile.IsDefault ? Path.GetFileNameWithoutExtension(route.Model.ModelPath) : null);
+    }
+
+    public ModelGatewayModelRoute? Resolve(string requested)
+        => _lookup.GetValueOrDefault(requested.Trim());
+
+    public int Count => _routes.Length;
+    public ModelGatewayModelRoute this[int index] => _routes[index];
+    public IEnumerator<ModelGatewayModelRoute> GetEnumerator()
+        => ((IEnumerable<ModelGatewayModelRoute>)_routes).GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void AddKeys(Func<ModelGatewayModelRoute, string?> keySelector)
+    {
+        foreach (var route in _routes)
+        {
+            var key = keySelector(route);
+            if (!string.IsNullOrWhiteSpace(key)) _lookup.TryAdd(key, route);
+        }
+    }
+}

--- a/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRuntimeController.cs
+++ b/src/LocalLlmConsole.App/Services/Gateway/ModelGatewayRuntimeController.cs
@@ -33,7 +33,9 @@ public sealed record ModelGatewayRouteCatalogActions(
 public sealed class ModelGatewayRouteCatalogApplicationService
 {
     private readonly StateStore _stateStore;
-    private readonly SemaphoreSlim _defaultRepairGate = new(1, 1);
+    private readonly SemaphoreSlim _catalogGate = new(1, 1);
+    private CachedCatalog? _cached;
+    private sealed record CachedCatalog(long Revision, ModelGatewayRouteSnapshot Routes);
 
     public ModelGatewayRouteCatalogApplicationService(StateStore stateStore)
     {
@@ -48,48 +50,42 @@ public sealed class ModelGatewayRouteCatalogApplicationService
         ArgumentNullException.ThrowIfNull(actions.EnsureDefaultProfilesAsync);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var models = await _stateStore.ListModelsAsync();
-        cancellationToken.ThrowIfCancellationRequested();
-        var profiles = await _stateStore.ListNamedModelLaunchProfilesAsync();
-        var missingDefaults = ModelsMissingDefaultProfiles(models, profiles);
-        if (missingDefaults.Count > 0)
-            profiles = await RepairDefaultProfilesAsync(models, profiles, actions, cancellationToken);
+        var cached = Volatile.Read(ref _cached);
+        if (cached?.Revision == _stateStore.CatalogRevision) return cached.Routes;
 
-        return BuildRoutes(models, profiles, cancellationToken);
-    }
-
-    private async Task<IReadOnlyList<NamedModelLaunchProfile>> RepairDefaultProfilesAsync(
-        IReadOnlyList<ModelRecord> models,
-        IReadOnlyList<NamedModelLaunchProfile> observedProfiles,
-        ModelGatewayRouteCatalogActions actions,
-        CancellationToken cancellationToken)
-    {
-        await _defaultRepairGate.WaitAsync(cancellationToken);
+        await _catalogGate.WaitAsync(cancellationToken);
         try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var profiles = observedProfiles;
-            var missingDefaults = ModelsMissingDefaultProfiles(models, profiles);
-            if (missingDefaults.Count == 0)
-                return profiles;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var revision = _stateStore.CatalogRevision;
+                cached = _cached;
+                if (cached?.Revision == revision) return cached.Routes;
 
-            // Recheck under the gate so simultaneous gateway requests do not all
-            // dispatch the same default-profile repair to the UI thread.
-            profiles = await _stateStore.ListNamedModelLaunchProfilesAsync();
-            missingDefaults = ModelsMissingDefaultProfiles(models, profiles);
-            if (missingDefaults.Count == 0)
-                return profiles;
+                var models = await _stateStore.ListModelsAsync();
+                var profiles = await _stateStore.ListNamedModelLaunchProfilesAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+                if (revision != _stateStore.CatalogRevision) continue;
+                var missingDefaults = ModelsMissingDefaultProfiles(models, profiles);
+                if (missingDefaults.Count > 0)
+                {
+                    await actions.EnsureDefaultProfilesAsync(missingDefaults, cancellationToken);
+                    profiles = await _stateStore.ListNamedModelLaunchProfilesAsync();
+                }
 
-            await actions.EnsureDefaultProfilesAsync(missingDefaults, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-            return await _stateStore.ListNamedModelLaunchProfilesAsync();
+                var routes = new ModelGatewayRouteSnapshot(BuildRoutes(models, profiles, cancellationToken));
+                // Both reads, repair, and route construction must describe one revision.
+                if (revision != _stateStore.CatalogRevision) continue;
+                Volatile.Write(ref _cached, new CachedCatalog(revision, routes));
+                return routes;
+            }
         }
         finally
         {
-            _defaultRepairGate.Release();
+            _catalogGate.Release();
         }
     }
-
     private static IReadOnlyList<ModelRecord> ModelsMissingDefaultProfiles(
         IReadOnlyList<ModelRecord> models,
         IReadOnlyList<NamedModelLaunchProfile> profiles)

--- a/src/LocalLlmConsole.App/Services/Infrastructure/StateStore.Catalog.cs
+++ b/src/LocalLlmConsole.App/Services/Infrastructure/StateStore.Catalog.cs
@@ -6,6 +6,7 @@ public sealed partial class StateStore
     {
         await WithConnectionAsync(async () =>
         {
+            InvalidateCatalog();
             await using var command = _connection.CreateCommand();
             command.CommandText = """
 INSERT INTO models (id, name, model_path, ownership, metadata_json, updated_at)
@@ -53,6 +54,7 @@ ON CONFLICT(id) DO UPDATE SET
     {
         await WithConnectionAsync(async () =>
         {
+            InvalidateCatalog();
             await using var command = _connection.CreateCommand();
             command.CommandText = "DELETE FROM models WHERE id = $id;";
             command.Parameters.AddWithValue("$id", id);
@@ -94,6 +96,7 @@ LIMIT 1;
                 var migrated = MigrateLegacyModelLaunchDefaults(settings, LooksLikeLegacyModelLaunchDefaultsJson(json), out var changed);
                 if (changed)
                 {
+                    InvalidateCatalog();
                     await using var update = _connection.CreateCommand();
                     update.CommandText = """
 UPDATE model_launch_profiles
@@ -126,6 +129,7 @@ WHERE model_id = $model_id;
 
     private async Task SaveDefaultProfileUnlockedAsync(string modelId, ModelLaunchSettings settings)
     {
+        InvalidateCatalog();
         var now = DateTimeOffset.UtcNow.ToString("O");
         var json = JsonSerializer.Serialize(settings);
         await using var update = _connection.CreateCommand();
@@ -201,6 +205,7 @@ VALUES ($id, $model_id, 'Default', $settings_json, $updated_at, 1);
         ArgumentNullException.ThrowIfNull(profile);
         await WithConnectionAsync(async () =>
         {
+            InvalidateCatalog();
             await using var command = _connection.CreateCommand();
             command.CommandText = """
 INSERT INTO model_launch_profiles (id, model_id, name, settings_json, updated_at, is_default)
@@ -226,6 +231,7 @@ ON CONFLICT(id) DO UPDATE SET
     {
         await WithConnectionAsync(async () =>
         {
+            InvalidateCatalog();
             await using var command = _connection.CreateCommand();
             command.CommandText = "DELETE FROM model_launch_profiles WHERE id = $id;";
             command.Parameters.AddWithValue("$id", profileId);

--- a/src/LocalLlmConsole.App/Services/Infrastructure/StateStore.cs
+++ b/src/LocalLlmConsole.App/Services/Infrastructure/StateStore.cs
@@ -8,6 +8,13 @@ public sealed partial class StateStore : IAsyncDisposable
     private readonly SqliteConnection _connection;
     private readonly SemaphoreSlim _dbLock = new(1, 1);
     private bool _disposed;
+    private long _catalogRevision;
+
+    // Changed under the database gate before any catalog write, including writes
+    // that might partially succeed. Readers retry snapshots spanning a revision.
+    public long CatalogRevision => Interlocked.Read(ref _catalogRevision);
+
+    private void InvalidateCatalog() => Interlocked.Increment(ref _catalogRevision);
 
     public string DatabasePath { get; }
 
@@ -39,6 +46,7 @@ public sealed partial class StateStore : IAsyncDisposable
     {
         await WithConnectionAsync(async () =>
         {
+            InvalidateCatalog();
             await ExecuteUnlockedAsync("PRAGMA journal_mode=WAL;");
             await ExecuteUnlockedAsync("PRAGMA foreign_keys=ON;");
             await ExecuteUnlockedAsync("PRAGMA busy_timeout=5000;");

--- a/tests/LocalLlmConsole.Tests/Gateway/GatewayCatalogCache.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Gateway/GatewayCatalogCache.Tests.cs
@@ -1,0 +1,125 @@
+using LocalLlmConsole.Models;
+using LocalLlmConsole.Services;
+
+namespace LocalLlmConsole.Tests;
+
+public sealed class GatewayCatalogCacheTests : ManagerRegressionTestBase
+{
+    [Fact]
+    public async Task CachedRoutesRefreshAfterEverySupportedCatalogMutation()
+    {
+        var root = CreateTempRoot();
+        await using var store = new StateStore(Path.Combine(root, "state", "catalog.db"));
+        await store.InitializeAsync();
+        var settings = ModelLaunchSettings.FromAppSettings(AppSettings.CreateDefault(root));
+        var model = new ModelRecord("one", "One", Path.Combine(root, "one.gguf"), OwnershipKind.External, "{}", DateTimeOffset.UtcNow);
+        var profile = new NamedModelLaunchProfile("default:one", model.Id, "Default", settings, model.UpdatedAt, true);
+        await store.UpsertModelAsync(model);
+        await store.SaveNamedModelLaunchProfileAsync(profile);
+        var catalog = new ModelGatewayRouteCatalogApplicationService(store);
+        var repairs = 0;
+        var actions = new ModelGatewayRouteCatalogActions(async (missing, token) =>
+        {
+            token.ThrowIfCancellationRequested();
+            repairs++;
+            foreach (var item in missing) await store.SaveModelLaunchSettingsAsync(item.Id, settings);
+        });
+        Task<IReadOnlyList<ModelGatewayModelRoute>> Read() => catalog.ListAsync(actions, TestContext.Current.CancellationToken);
+
+        var original = await Read();
+        Assert.Same(original, await Read());
+        await store.UpsertModelAsync(model with { Name = "Renamed", ModelPath = Path.Combine(root, "renamed.gguf") });
+        var renamed = await Read();
+        Assert.NotSame(original, renamed);
+        Assert.Equal("Renamed", Assert.Single(renamed).Model.Name);
+        Assert.Equal("One", Assert.Single(original).Model.Name);
+
+        await store.SaveNamedModelLaunchProfileAsync(profile with { Settings = settings with { CustomParameters = "--alias new-alias" } });
+        var aliased = await Read();
+        Assert.Equal("new-alias", Assert.Single(aliased).Id);
+        Assert.NotNull(ModelGatewayRequestResolver.ResolveModel(aliased, "renamed.gguf"));
+
+        await store.SaveModelLaunchSettingsAsync(model.Id, settings with { ContextSize = 8192 });
+        Assert.Equal(8192, Assert.Single(await Read()).Profile.Settings.ContextSize);
+        var alternate = profile with { Id = "alternate", Name = "Alternate", IsDefault = false };
+        await store.SaveNamedModelLaunchProfileAsync(alternate);
+        Assert.Equal(2, (await Read()).Count);
+        await store.DeleteNamedModelLaunchProfileAsync(alternate.Id);
+        Assert.Single(await Read());
+
+        await store.DeleteNamedModelLaunchProfileAsync(profile.Id);
+        Assert.True(Assert.Single(await Read()).Profile.IsDefault);
+        Assert.Equal(1, repairs);
+        await store.UpsertModelAsync(model with { Id = "two", Name = "Two" });
+        Assert.Equal(2, (await Read()).Count);
+        Assert.Equal(2, repairs);
+        await store.DeleteModelAsync(model.Id);
+        Assert.Equal("two", Assert.Single(await Read()).Model.Id);
+        await store.DeleteModelAsync("two");
+        Assert.Empty(await Read());
+    }
+
+    [Fact]
+    public async Task ConcurrentReadersShareRepairAndDoNotPublishAnObsoleteRevision()
+    {
+        var root = CreateTempRoot();
+        await using var store = new StateStore(Path.Combine(root, "state", "catalog.db"));
+        await store.InitializeAsync();
+        var model = new ModelRecord("one", "One", Path.Combine(root, "one.gguf"), OwnershipKind.External, "{}", DateTimeOffset.UtcNow);
+        await store.UpsertModelAsync(model);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var catalog = new ModelGatewayRouteCatalogApplicationService(store);
+        var repairs = 0;
+        var actions = new ModelGatewayRouteCatalogActions(async (_, token) =>
+        {
+            repairs++;
+            started.SetResult();
+            await release.Task.WaitAsync(token);
+            await store.SaveModelLaunchSettingsAsync(model.Id, ModelLaunchSettings.FromAppSettings(AppSettings.CreateDefault(root)));
+        });
+        var first = catalog.ListAsync(actions, TestContext.Current.CancellationToken);
+        await started.Task.WaitAsync(TestContext.Current.CancellationToken);
+        var readers = Enumerable.Range(0, 8).Select(_ => catalog.ListAsync(actions, TestContext.Current.CancellationToken)).ToArray();
+        using var canceled = new CancellationTokenSource();
+        var canceledRead = catalog.ListAsync(actions, canceled.Token);
+        canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledRead);
+        await store.UpsertModelAsync(model with { Name = "Changed during repair" });
+        release.SetResult();
+        var result = await first;
+        Assert.Equal(1, repairs);
+        Assert.Equal("Changed during repair", Assert.Single(result).Model.Name);
+        foreach (var read in readers) Assert.Same(result, await read);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => catalog.ListAsync(actions, canceled.Token));
+    }
+
+    [Fact]
+    public void IndexedResolutionMatchesLegacyPrecedenceAndDetachesTheInputList()
+    {
+        var root = CreateTempRoot();
+        var settings = ModelLaunchSettings.FromAppSettings(AppSettings.CreateDefault(root));
+        var now = DateTimeOffset.UtcNow;
+        var routes = new List<ModelGatewayModelRoute>();
+        for (var index = 0; index < 50; index++)
+        {
+            var model = new ModelRecord($"model-{index}", $"name-{index}", Path.Combine(root, $"file-{index}.gguf"), OwnershipKind.External, "{}", now);
+            var profile = new NamedModelLaunchProfile($"profile-{index}", model.Id, $"Profile {index}", settings, now, index % 2 == 0);
+            routes.Add(new ModelGatewayModelRoute(model, profile, $"name-{(index + 1) % 50}"));
+        }
+        var snapshot = new ModelGatewayRouteSnapshot(routes);
+        foreach (var route in routes)
+        {
+            foreach (var key in new[] { route.Id, route.LegacyId, route.Name, route.Profile.Id, route.Model.Name,
+                Path.GetFileName(route.Model.ModelPath), Path.GetFileNameWithoutExtension(route.Model.ModelPath), "missing", "" })
+            {
+                var requested = " " + key.ToUpperInvariant() + " ";
+                Assert.Equal(ModelGatewayRequestResolver.ResolveModel(routes, requested), ModelGatewayRequestResolver.ResolveModel(snapshot, requested));
+            }
+        }
+        routes.Clear();
+        Assert.Equal(50, snapshot.Count);
+        Assert.Equal(50, snapshot.ToArray().Length);
+        Assert.Null(snapshot.Resolve("missing"));
+    }
+}


### PR DESCRIPTION
Closes #54. Dependencies: none; independent of #55. Suggested merge after #55, then update this branch against main and rerun required checks.

Gateway requests previously reloaded the complete model/profile catalog and rebuilt aliases on each request. The catalog now reuses an immutable snapshot until StateStore's catalog revision changes, and resolves supported IDs through a prebuilt lookup. Model/profile writes, legacy default repair, and initialization invalidate under the existing database gate. Readers retry if a write overlaps construction; concurrent readers share a single rebuild.

Lookup ordering remains identical for aliases, legacy IDs, names, profile IDs, and default-model filenames, including case-insensitive collisions. Running sessions are still queried live. There is no database migration or change to admission, loading, or saved-profile contracts. Future catalog write paths must invalidate the revision; this is documented in the architecture guide.

Validation: 69 gateway tests passed, including cache reuse, mutation invalidation, repair during concurrent reads, canceled waiters, detached snapshots, and indexed-versus-legacy lookup equivalence. Full local release gate passed: 936 regression tests plus 54 WPF tests, no failures/skips, coverage thresholds met, and build/formatting/code-shape/docs/whitespace/package audit passed. Cache reuse is verified behaviorally; no latency percentage is claimed. Production Manager data was not used. GitHub checks run on this PR.

Release note: docs/releases/unreleased/54.md. No manual UI check is required for this catalog-only change.

Combined validation: all three PR heads (#55, #57, #58) were applied together on a temporary local branch from main at e9a1d1f. They combined without conflicts and passed the full release gate: 956 regression tests plus 54 WPF tests (1,010 total), no failures/skips, and all quality/package checks. This does not replace updating each remaining PR against main and rerunning required checks after a merge.
