### PR TITLE
Render selected telemetry before slow peer endpoints and GPU refresh

### DIFF
--- a/docs/performance/progressive-telemetry.md
+++ b/docs/performance/progressive-telemetry.md
@@ -1,0 +1,37 @@
+# Progressive dashboard telemetry
+
+Issue: [#56](https://github.com/alekk89/llama-cpp-windows-manager/issues/56).
+
+The dashboard now applies a completed response for the currently selected
+session before waiting for other sessions or the GPU summary. The poller invokes
+completion callbacks serially on the caller's synchronization context while
+retaining its existing bounded HTTP concurrency. Results returned to batch
+consumers retain the original session order.
+
+Endpoint health, lifetime-token accounting, and idle-unload decisions still run
+once after the complete batch. The final render rechecks the selection and any
+unload result, without applying the same selected sample twice. A failed callback
+or canceled refresh cancels and drains outstanding polls before the refresh guard
+is released.
+
+This is a presentation-latency improvement. A slow endpoint can still lengthen
+the overall batch and delay the next refresh. Polling cadence, endpoint timeouts,
+retention policy, and background collection are unchanged. There is no permanent
+background polling service or cache of stale counter samples.
+
+Run the deterministic behavioral checks with:
+
+```powershell
+dotnet test --project tests/LocalLlmConsole.Tests --filter-class '*ProgressiveTelemetryTests' --output Detailed
+```
+
+The tests hold a peer endpoint and GPU refresh behind explicit completion gates.
+They assert that the healthy selected model renders before either gate opens,
+then verify complete batch accounting, selection changes, unload rendering,
+bounded concurrency, cancellation, and callback-error recovery. This establishes
+ordering rather than claiming a hardware-independent millisecond improvement.
+
+A manual multi-session UI check remains useful before release: select a healthy
+session while another endpoint is slow, switch the selection during polling,
+and check chart continuity and the final endpoint status. Use an isolated test
+environment and the supported control interface for runtime operations.

--- a/docs/releases/unreleased/56.md
+++ b/docs/releases/unreleased/56.md
@@ -1,0 +1,1 @@
+- Show completed telemetry for the selected model before slower peer endpoints and GPU-summary refreshes finish.

--- a/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeDashboardRefreshApplicationService.cs
+++ b/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeDashboardRefreshApplicationService.cs
@@ -77,65 +77,85 @@ public sealed class RuntimeDashboardRefreshApplicationService
             if (request.RenderOverview)
                 actions.RefreshOverviewSessionRows();
 
-            var pollResults = await _telemetry.PollSessionsAsync(actions.SessionSnapshots(), cancellationToken);
+            RuntimeMetricPollResult? rendered = null;
+            var pollResults = await _telemetry.PollSessionsAsync(actions.SessionSnapshots(), async completed =>
+            {
+                if (request.RenderOverview)
+                    (_, rendered) = await RenderSelectionAsync(request, actions, [completed], rendered, completedOnly: true);
+            }, cancellationToken);
             await actions.ApplyEndpointHealthAsync(pollResults);
             await actions.TrackLifetimeTokenDeltasAsync(pollResults);
             await actions.ApplyIdleUnloadPoliciesAsync(pollResults);
 
-            if (request.RenderOverview)
-                await actions.SetGpuMetricAsync(await actions.CachedGpuSummaryAsync());
-
-            var selectedOverviewModel = actions.SelectedOverviewModel();
-            var selectedOverviewModelSession = selectedOverviewModel is null
-                ? null
-                : actions.SessionForModel(selectedOverviewModel.Id);
-            var selection = _selection.Select(new RuntimeDashboardSelectionRequest(
-                selectedOverviewModel,
-                selectedOverviewModel is not null && actions.IsModelActive(selectedOverviewModel),
-                selectedOverviewModel is not null && actions.IsModelLoaded(selectedOverviewModel),
-                selectedOverviewModelSession,
-                actions.SelectedSession(),
-                actions.ActiveSessionSettings(),
-                actions.ActiveRuntimeSettings(),
-                request.Settings,
-                request.ActiveModelId,
-                request.ActiveRuntimeId));
-            if (selection.SelectedOverviewModelHasNoRunningSession)
-            {
-                await actions.RenderStoppedSelectedOverviewModelAsync(selectedOverviewModel, request.RenderOverview);
-                return RuntimeDashboardRefreshApplicationOutcome.RenderedStoppedSelection;
-            }
-
-            if (selection.SelectSelectedOverviewModel)
-                actions.SetActiveRuntimeSettings(actions.SelectModel(selectedOverviewModel!.Id).ActiveSettings);
-
-            var selectedSession = selection.Session;
-            var runtimeKey = selection.RuntimeKey;
-            var selectedPollResult = selectedSession is null
-                ? null
-                : pollResults.FirstOrDefault(result => string.Equals(result.RuntimeKey, runtimeKey, StringComparison.Ordinal));
-
-            var (modelName, _) = await actions.ActiveRuntimeLabelsAsync();
-            if (request.RenderOverview)
-                actions.RefreshModelStatusMetric(modelName);
-
             if (request.RuntimeState == LlamaRuntimeState.Failed)
                 await actions.SaveActiveRuntimeSessionsAsync();
-
-            await _metricsApplication.ApplyAsync(
-                new RuntimeDashboardMetricsApplicationRequest(
-                    request.RenderOverview,
-                    selectedSession,
-                    selection.MetricsSettings,
-                    selectedPollResult,
-                    runtimeKey),
-                actions.MetricsActions);
-            return RuntimeDashboardRefreshApplicationOutcome.Applied;
+            var (outcome, _) = await RenderSelectionAsync(request, actions, pollResults, rendered, completedOnly: false);
+            if (request.RenderOverview)
+                await actions.SetGpuMetricAsync(await actions.CachedGpuSummaryAsync());
+            return outcome;
         }
         finally
         {
             actions.UpdateOverviewModelActions();
         }
+    }
+
+    private async Task<(RuntimeDashboardRefreshApplicationOutcome Outcome, RuntimeMetricPollResult? Rendered)> RenderSelectionAsync(
+        RuntimeDashboardRefreshApplicationRequest request,
+        RuntimeDashboardRefreshApplicationActions actions,
+        IReadOnlyList<RuntimeMetricPollResult> pollResults,
+        RuntimeMetricPollResult? previouslyRendered,
+        bool completedOnly)
+    {
+        var selectedOverviewModel = actions.SelectedOverviewModel();
+        var selectedOverviewModelSession = selectedOverviewModel is null
+            ? null
+            : actions.SessionForModel(selectedOverviewModel.Id);
+        var selection = _selection.Select(new RuntimeDashboardSelectionRequest(
+            selectedOverviewModel,
+            selectedOverviewModel is not null && actions.IsModelActive(selectedOverviewModel),
+            selectedOverviewModel is not null && actions.IsModelLoaded(selectedOverviewModel),
+            selectedOverviewModelSession,
+            actions.SelectedSession(),
+            actions.ActiveSessionSettings(),
+            actions.ActiveRuntimeSettings(),
+            request.Settings,
+            request.ActiveModelId,
+            request.ActiveRuntimeId));
+        if (selection.SelectedOverviewModelHasNoRunningSession && !completedOnly)
+        {
+            await actions.RenderStoppedSelectedOverviewModelAsync(selectedOverviewModel, request.RenderOverview);
+            return (RuntimeDashboardRefreshApplicationOutcome.RenderedStoppedSelection, null);
+        }
+
+        var selectedSession = selection.Session;
+        var runtimeKey = selection.RuntimeKey;
+        var selectedPollResult = selectedSession is null
+            ? null
+            : pollResults.FirstOrDefault(result => string.Equals(result.RuntimeKey, runtimeKey, StringComparison.Ordinal)
+                && string.Equals(result.Session.SessionId, selectedSession.SessionId, StringComparison.Ordinal));
+
+        if (completedOnly && selectedPollResult is null)
+            return (RuntimeDashboardRefreshApplicationOutcome.Applied, previouslyRendered);
+        if (selectedSession is { IsRunning: true } && selectedPollResult is not null
+            && ReferenceEquals(selectedPollResult, previouslyRendered))
+            return (RuntimeDashboardRefreshApplicationOutcome.Applied, previouslyRendered);
+        if (selection.SelectSelectedOverviewModel)
+            actions.SetActiveRuntimeSettings(actions.SelectModel(selectedOverviewModel!.Id).ActiveSettings);
+
+        var (modelName, _) = await actions.ActiveRuntimeLabelsAsync();
+        if (request.RenderOverview)
+            actions.RefreshModelStatusMetric(modelName);
+
+        await _metricsApplication.ApplyAsync(
+            new RuntimeDashboardMetricsApplicationRequest(
+                request.RenderOverview,
+                selectedSession,
+                selection.MetricsSettings,
+                selectedPollResult,
+                runtimeKey),
+            actions.MetricsActions);
+        return (RuntimeDashboardRefreshApplicationOutcome.Applied, selectedPollResult);
     }
 
     private static void Validate(RuntimeDashboardRefreshApplicationActions actions)

--- a/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeMetricPollerService.cs
+++ b/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeMetricPollerService.cs
@@ -23,6 +23,40 @@ public sealed class RuntimeMetricPollerService
     public static string RuntimeKey(LoadedModelSessionSnapshot session)
         => RuntimeMetricIdentity.RuntimeKey(session);
 
+    public async Task<RuntimeMetricPollResult[]> PollSessionsAsync(
+        IReadOnlyList<LoadedModelSessionSnapshot> sessions,
+        Func<RuntimeMetricPollResult, Task> onCompleted,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(onCompleted);
+        using var polling = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var tasks = sessions.Select(session => PollSessionBoundedAsync(session, polling.Token)).ToArray();
+        var pending = tasks.ToList();
+        try
+        {
+            while (pending.Count > 0)
+            {
+                var completed = await Task.WhenAny(pending);
+                pending.Remove(completed);
+                var result = await completed;
+                cancellationToken.ThrowIfCancellationRequested();
+                // Await callbacks serially on the caller's context. HTTP requests
+                // remain concurrent, but UI and counter consumers never overlap.
+                await onCompleted(result);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            return await Task.WhenAll(tasks);
+        }
+        catch
+        {
+            polling.Cancel();
+            // Do not release the refresh guard while abandoned polls still run.
+            try { await Task.WhenAll(tasks); }
+            catch { /* Preserve the original polling or callback failure. */ }
+            throw;
+        }
+    }
+
     private async Task<RuntimeMetricPollResult> PollSessionBoundedAsync(
         LoadedModelSessionSnapshot session,
         CancellationToken cancellationToken)

--- a/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeTelemetryApplicationService.cs
+++ b/src/LocalLlmConsole.App/Services/Runtimes/Telemetry/RuntimeTelemetryApplicationService.cs
@@ -44,6 +44,15 @@ public sealed class RuntimeTelemetryApplicationService
         return _poller.PollSessionsAsync(pollableSessions, cancellationToken);
     }
 
+    public Task<RuntimeMetricPollResult[]> PollSessionsAsync(
+        IEnumerable<LoadedModelSessionSnapshot> sessions,
+        Func<RuntimeMetricPollResult, Task> onCompleted,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+        return _poller.PollSessionsAsync(_refreshCoordinator.PollableSessions(sessions), onCompleted, cancellationToken);
+    }
+
     public RuntimeMetricSummaryResult ApplyMetricSummary(
         string runtimeKey,
         IReadOnlyList<PrometheusSample> samples,

--- a/tests/LocalLlmConsole.Tests/Overview/ProgressiveTelemetry.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Overview/ProgressiveTelemetry.Tests.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using LocalLlmConsole.Models;
+using LocalLlmConsole.Services;
+
+namespace LocalLlmConsole.Tests;
+
+public sealed class ProgressiveTelemetryTests : ManagerRegressionTestBase
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task HealthySelectionRendersBeforeSlowPeerAndGpuWithoutDuplicatingAccounting(bool changeSelection)
+    {
+        using var handler = new HeldEndpointHandler(port => port == 8082);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        var refresh = probe.RefreshAsync();
+        try
+        {
+            await probe.Rendered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.False(refresh.IsCompleted);
+            Assert.Single(probe.Summaries);
+            Assert.Equal(8081, Assert.Single(probe.Summaries[0].Samples).Value);
+            Assert.Empty(probe.Batches);
+            Assert.False(probe.GpuStarted.Task.IsCompleted);
+            Assert.Equal(RuntimeDashboardRefreshApplicationOutcome.Skipped, await probe.RefreshAsync());
+
+            if (changeSelection) probe.Selected = probe.Sessions[1];
+            handler.Release.SetResult();
+            await probe.GpuStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(["health:2", "lifetime:2", "idle:2"], probe.Batches);
+            Assert.Equal(changeSelection ? 2 : 1, probe.Summaries.Count);
+            Assert.Equal(changeSelection ? 8082 : 8081, Assert.Single(probe.Summaries[^1].Samples).Value);
+            Assert.False(refresh.IsCompleted);
+            probe.ReleaseGpu.SetResult();
+            Assert.Equal(RuntimeDashboardRefreshApplicationOutcome.Applied, await refresh);
+            Assert.Equal(1, probe.FinalUpdates);
+        }
+        finally
+        {
+            handler.Release.TrySetResult();
+            probe.ReleaseGpu.TrySetResult();
+            await refresh;
+        }
+    }
+
+    [Fact]
+    public async Task SelectionUnloadedByBatchPolicyIsRenderedAsNoRuntime()
+    {
+        using var handler = new HeldEndpointHandler(_ => false);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        probe.UnloadDuringPolicy = true;
+        probe.ReleaseGpu.SetResult();
+        await probe.RefreshAsync();
+        Assert.Equal(2, probe.Summaries.Count);
+        Assert.Same(RuntimeMetricSummaryPresentation.NoRuntime, probe.Summaries[^1]);
+        Assert.Equal(["health:2", "lifetime:2", "idle:2"], probe.Batches);
+    }
+
+    [Fact]
+    public async Task ReplacementSessionDoesNotTreatThePreviousSessionSampleAsFresh()
+    {
+        using var handler = new HeldEndpointHandler(port => port == 8082);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        var refresh = probe.RefreshAsync();
+        try
+        {
+            await probe.Rendered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            probe.Selected = probe.Selected! with { SessionId = "replacement" };
+            handler.Release.SetResult();
+            probe.ReleaseGpu.SetResult();
+            await refresh;
+            Assert.Equal(2, probe.Summaries.Count);
+            Assert.NotNull(probe.Summaries[^1].LastKnownCapturedAt);
+        }
+        finally
+        {
+            handler.Release.TrySetResult();
+            probe.ReleaseGpu.TrySetResult();
+            await refresh;
+        }
+    }
+
+    [Fact]
+    public async Task CallbackFailureCancelsAndDrainsPendingPollsAndPreservesTheError()
+    {
+        using var handler = new HeldEndpointHandler(port => port == 8082);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        var poller = new RuntimeMetricPollerService(http);
+        var expected = new InvalidOperationException("render failed");
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => poller.PollSessionsAsync(
+            probe.Sessions, _ => Task.FromException(expected), TestContext.Current.CancellationToken));
+        Assert.Same(expected, error);
+        Assert.Equal(0, handler.Active);
+        Assert.Single(await poller.PollSessionsAsync([probe.Sessions[0]], _ => Task.CompletedTask, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CancellationDrainsActiveAndQueuedPollsWithoutRenderingFailures()
+    {
+        using var handler = new HeldEndpointHandler(_ => true);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        var poller = new RuntimeMetricPollerService(http, maxConcurrentSessions: 1);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var callbacks = 0;
+        var pending = poller.PollSessionsAsync(probe.Sessions, _ => { callbacks++; return Task.CompletedTask; }, cancellation.Token);
+        await handler.Started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pending);
+        Assert.Equal(0, callbacks);
+        Assert.Equal(0, handler.Active);
+    }
+
+    [Fact]
+    public async Task PollConcurrencyRemainsBoundedAndCallbacksAreSerial()
+    {
+        using var handler = new HeldEndpointHandler(_ => true);
+        using var http = new HttpClient(handler);
+        var probe = CreateProbe(http);
+        var sessions = Enumerable.Range(0, 6).Select(index => probe.Sessions[0] with
+        {
+            SessionId = $"session-{index}",
+            LaunchSettings = probe.Settings with { Port = 8081 + index, EnableMetrics = false }
+        }).ToArray();
+        var activeCallbacks = 0;
+        var callbackCount = 0;
+        var pending = new RuntimeMetricPollerService(http, maxConcurrentSessions: 2).PollSessionsAsync(sessions, async _ =>
+        {
+            Assert.Equal(1, Interlocked.Increment(ref activeCallbacks));
+            await Task.Yield();
+            callbackCount++;
+            Interlocked.Decrement(ref activeCallbacks);
+        }, TestContext.Current.CancellationToken);
+        try
+        {
+            Assert.Equal(2, handler.Active);
+            handler.Release.SetResult();
+            var results = await pending;
+            Assert.Equal(sessions.Select(s => s.SessionId), results.Select(r => r.Session.SessionId));
+            Assert.Equal(6, callbackCount);
+            Assert.InRange(handler.PeakActive, 1, 2);
+        }
+        finally
+        {
+            handler.Release.TrySetResult();
+            await pending;
+        }
+    }
+
+    private DashboardProbe CreateProbe(HttpClient http)
+    {
+        var root = CreateTempRoot();
+        var settings = AppSettings.CreateDefault(root) with { Port = 8081, EnableMetrics = true };
+        var first = RuntimeMetricSession(root, settings);
+        var second = RuntimeMetricSession(root, settings with { Port = 8082 }) with { SessionId = "second" };
+        return new DashboardProbe(http, settings, [first, second]);
+    }
+
+    private sealed class DashboardProbe
+    {
+        public AppSettings Settings { get; }
+        public LoadedModelSessionSnapshot[] Sessions { get; }
+        public LoadedModelSessionSnapshot? Selected { get; set; }
+        public List<RuntimeMetricSummaryPresentation> Summaries { get; } = [];
+        public List<string> Batches { get; } = [];
+        public TaskCompletionSource Rendered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource GpuStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseGpu { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool UnloadDuringPolicy { get; set; }
+        public int FinalUpdates { get; private set; }
+        private readonly RuntimeDashboardRefreshApplicationService _service;
+
+        public DashboardProbe(HttpClient http, AppSettings settings, LoadedModelSessionSnapshot[] sessions)
+        {
+            Settings = settings;
+            Sessions = sessions;
+            Selected = sessions[0];
+            var telemetry = new RuntimeTelemetryApplicationService(new RuntimeMetricPollerService(http),
+                new RuntimeDashboardRefreshCoordinator(), new RuntimeMetricSummaryTracker(),
+                new RuntimeLifetimeCounterTracker(), new RuntimeIdleUnloadPolicyService());
+            _service = new RuntimeDashboardRefreshApplicationService(telemetry, new RuntimeDashboardSelectionService(),
+                new RuntimeDashboardMetricsApplicationService(telemetry, new RuntimeDashboardRenderDecisionService(), new RuntimeMetricRowsRenderService()));
+        }
+
+        public Task<RuntimeDashboardRefreshApplicationOutcome> RefreshAsync()
+            => _service.RefreshAsync(new RuntimeDashboardRefreshApplicationRequest(
+                new RuntimeDashboardRefreshTarget(true, true, true, true), true, Settings, "", "", LlamaRuntimeState.Loaded, true),
+                new RuntimeDashboardRefreshApplicationActions(
+                    () => Task.CompletedTask, () => { }, () => Sessions,
+                    results => Batch("health", results), results => Batch("lifetime", results),
+                    results => { if (UnloadDuringPolicy) Selected = Selected! with { IsRunning = false }; return Batch("idle", results); },
+                    () => null, _ => false, _ => false, _ => null, () => Selected, () => null, () => null,
+                    _ => new RuntimeSessionSelectResult(false, null), _ => { },
+                    () => Task.FromResult(("Model", "Runtime")), _ => { }, () => Task.CompletedTask,
+                    async () =>
+                    {
+                        GpuStarted.TrySetResult();
+                        await ReleaseGpu.Task.WaitAsync(TestContext.Current.CancellationToken);
+                        return HostHardwareSnapshotParser.Parse("GPU");
+                    },
+                    _ => Task.CompletedTask, (_, _) => Task.CompletedTask,
+                    new RuntimeDashboardMetricsApplicationActions(
+                        _ => Task.FromResult<RuntimeMtpTokenSnapshot?>(null), _ => { },
+                        summary => { Summaries.Add(summary); Rendered.TrySetResult(); }),
+                    () => FinalUpdates++), TestContext.Current.CancellationToken);
+
+        private Task Batch(string name, IReadOnlyList<RuntimeMetricPollResult> results)
+        {
+            Batches.Add($"{name}:{results.Count}");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class HeldEndpointHandler(Func<int, bool> hold) : HttpMessageHandler
+    {
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int Active;
+        public int PeakActive;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var active = Interlocked.Increment(ref Active);
+            int observed;
+            do { observed = PeakActive; } while (active > observed && Interlocked.CompareExchange(ref PeakActive, active, observed) != observed);
+            try
+            {
+                var port = request.RequestUri!.Port;
+                if (hold(port))
+                {
+                    Started.TrySetResult();
+                    await Release.Task.WaitAsync(cancellationToken);
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(request.RequestUri.AbsolutePath == "/metrics"
+                        ? $"llama_tokens_predicted_total {port}\n" : "[]")
+                };
+            }
+            finally { Interlocked.Decrement(ref Active); }
+        }
+    }
+}

--- a/tests/LocalLlmConsole.Tests/Runtime/RuntimeTelemetry.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Runtime/RuntimeTelemetry.Tests.cs
@@ -516,11 +516,6 @@ public sealed class RuntimeTelemetryTests : ManagerRegressionTestBase
             [
                 "mark",
                 "overview",
-                "health:1",
-                "lifetime:1",
-                "idle:1",
-                "gpu-read",
-                "gpu:GPU summary",
                 $"select:{model.Id}",
                 "active:8081",
                 "labels",
@@ -528,6 +523,11 @@ public sealed class RuntimeTelemetryTests : ManagerRegressionTestBase
                 "metrics-log",
                 "metrics-rows",
                 "metrics-summary",
+                "health:1",
+                "lifetime:1",
+                "idle:1",
+                "gpu-read",
+                "gpu:GPU summary",
                 "actions"
             ],
             calls);


### PR DESCRIPTION
Closes #56. Dependencies: none; suggested merge after #55 and #57, updating against main and rerunning required checks at each step.

A selected model's dashboard previously waited for all peer endpoints and GPU-summary work before showing its telemetry. Completed selected-session responses now render promptly through serial callbacks; the existing bounded HTTP polling continues in parallel. Final rendering rechecks selection and stopped/replaced sessions without applying the same sample twice.

Endpoint health, lifetime-token accounting, and idle-unload decisions still consume the complete batch once. Poll results retain session order, the refresh overlap guard remains active, and callback failures or cancellation cancel and drain outstanding polls before releasing it. Polling cadence, lifecycle policy, request schemas, and persistence contracts are unchanged. A slow endpoint can still lengthen the complete batch and delay the next refresh; this PR improves presentation latency, not polling frequency or inference speed.

Validation: 22 focused telemetry tests passed. Deterministic completion gates prove that healthy selected telemetry renders while a peer endpoint and GPU summary are pending; tests also cover selection changes, stop/replacement, single batch accounting, serial callbacks, bounded concurrency, cancellation, and error recovery. Full local release gate passed: 940 regression tests plus 54 WPF tests, no failures/skips, coverage thresholds met, and build/formatting/code-shape/docs/whitespace/package audit passed. GitHub checks run on this PR.

Release note: docs/releases/unreleased/56.md. Methodology and limitations: docs/performance/progressive-telemetry.md. Before release, perform the documented multi-session UI smoke check in an isolated environment; live production models were not used for validation.

Combined validation: all three PR heads (#55, #57, #58) were applied together on a temporary local branch from main at e9a1d1f. They combined without conflicts and passed the full release gate: 956 regression tests plus 54 WPF tests (1,010 total), no failures/skips, and all quality/package checks. This does not replace updating each remaining PR against main and rerunning required checks after a merge.
