### PR TITLE
Fix double-counted accepted draft token metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ endpoints on native Windows or Ubuntu/WSL.
 * Runs and supervises several model servers on separate ports.
 * Provides direct endpoints and an optional shared gateway.
 * Tracks runtime health, logs, token usage, hardware metrics, and GPU energy.
+  Draft acceptance uses accepted and generated token totals without counting
+  the per-position breakdown a second time.
 * Adds independent live UI and Text scaling on top of Windows per-monitor DPI
   scaling, remembers resized tables and page sections, and keeps Settings
   responsive between one and two columns.

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -274,6 +274,11 @@ builds and must be described that way.
   KV-cache values, and currently visible raw Prometheus metrics. Mix unrelated
   metrics in one card, confirm cards have no fixed type, reset restores the default
   layout, and confirm all choices survive restart.
+- With a speculative runtime exposing both aggregate and per-position accepted
+  token counters, confirm Overview counts only the aggregate. For 40,968 draft
+  tokens, 33,439 accepted tokens, and position counts of 17,941 and 15,498, expect
+  33,439 accepted and 81.6% acceptance. Confirm the raw metrics still include
+  the position breakdown and aggregate-only runtimes retain their totals.
 - With multiple models loaded, switch the Overview telemetry source and confirm
   the matching Loaded Model Sessions row remains highlighted across refreshes.
   Unload all models and confirm the grid has no highlighted row.

--- a/docs/releases/unreleased/59.md
+++ b/docs/releases/unreleased/59.md
@@ -1,0 +1,2 @@
+- Fix double-counted accepted draft tokens when llama.cpp reports per-position
+  counters, restoring accurate draft acceptance percentages and token rates.

--- a/src/LocalLlmConsole.App/Localization/Strings.en.json
+++ b/src/LocalLlmConsole.App/Localization/Strings.en.json
@@ -1100,7 +1100,7 @@
   "Help.Article.endpoint-inspection.Detail.3": "Gateway inspection reads /health, /v1/models, and /running.",
   "Help.Article.endpoint-inspection.Action.1": "Open Overview",
   "Help.Article.metrics.Title": "Read live metrics",
-  "Help.Article.metrics.Summary": "Customizable cards combine live status, runtime summaries, and available raw metrics.",
+  "Help.Article.metrics.Summary": "Customizable cards combine live status, runtime summaries, and available raw metrics. Draft acceptance counts each accepted token once, without adding per-position breakdowns.",
   "Help.Article.metrics.Detail.1": "Choose Customize or right-click a card to add or remove metrics, move cards, select snapped sizes, and restore the default layout.",
   "Help.Article.metrics.Detail.2": "Charts are offered for compatible summaries and raw gauges; the searchable picker follows the metrics exposed by the selected runtime.",
   "Help.Article.metrics.Detail.3": "If loading stalls or throughput collapses, inspect the live runtime log first.",

--- a/src/LocalLlmConsole.App/Services/App/HelpCatalogService.cs
+++ b/src/LocalLlmConsole.App/Services/App/HelpCatalogService.cs
@@ -125,7 +125,7 @@ public sealed partial class HelpCatalogService
             "metrics",
             "overview",
             "Read live metrics",
-            "Customizable cards combine live status, runtime summaries, and available raw metrics.",
+            "Customizable cards combine live status, runtime summaries, and available raw metrics. Draft acceptance counts each accepted token once, without adding per-position breakdowns.",
             [
                 "Right-click a card to add or remove metrics, set an optional title, manage charts, remove it, or restore the default layout; drag or resize its visible border directly. Choose Lock beside Add card to keep the current card dimensions while resizing the window; cards wrap before shrinking and border resizing returns when you unlock them.",
                 "Cards keep a minimum gap, and matching top or bottom edges align when adjacent cards are resized. Overview retains its cards, charts, and latest readings while you visit another page, so returning does not wait for a full dashboard rebuild.",
@@ -133,7 +133,7 @@ public sealed partial class HelpCatalogService
                 "If loading stalls or throughput collapses, inspect the live runtime log first. Settings can place its latest entry at the top or bottom without changing the stored log."
             ],
             [Action("Open Overview", "overview"), Action("Open Logs", "logs")],
-            ["tokens per second", "gpu", "kv cache", "slow", "telemetry"]),
+            ["tokens per second", "gpu", "kv cache", "slow", "telemetry", "draft acceptance", "per-position"]),
 
         Article(
             "usage-history",

--- a/src/LocalLlmConsole.Core/Services/Runtimes/RuntimeDashboardService.cs
+++ b/src/LocalLlmConsole.Core/Services/Runtimes/RuntimeDashboardService.cs
@@ -228,7 +228,7 @@ public static class RuntimeDashboardService
         => RuntimeMetrics.Sum(samples, ["mtp", "tokens", "accepted", "total"], ["seconds", "duration"])
            ?? RuntimeMetrics.Sum(samples, ["draft", "tokens", "accepted", "total"], ["seconds", "duration"])
            ?? RuntimeMetrics.Sum(samples, ["speculative", "tokens", "accepted", "total"], ["seconds", "duration"])
-           ?? RuntimeMetrics.Sum(samples, ["spec", "tokens", "accepted", "total"], ["seconds", "duration"])
+           ?? RuntimeMetrics.Sum(samples, ["spec", "tokens", "accepted", "total"], ["seconds", "duration", "per_pos"])
            ?? RuntimeMetrics.Sum(samples, ["mtp", "acc", "tokens", "total"], ["seconds", "duration"])
            ?? RuntimeMetrics.Sum(samples, ["draft", "acc", "tokens", "total"], ["seconds", "duration"])
            ?? RuntimeMetrics.Sum(samples, ["speculative", "acc", "tokens", "total"], ["seconds", "duration"]);

--- a/tests/LocalLlmConsole.Tests/Runtime/RuntimeMetricParsing.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Runtime/RuntimeMetricParsing.Tests.cs
@@ -363,6 +363,63 @@ public sealed class RuntimeMetricParsingTests : ManagerRegressionTestBase
         Assert.Equal(11, tracker.LastKnownSamples("model|runtime|8081").Count);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RuntimeMetricSummaryTrackerCountsAcceptedDraftTokensOnce(bool includePerPositionCounters)
+    {
+        var settings = AppSettings.CreateDefault(CreateTempRoot()) with { SpeculativeType = "draft-mtp" };
+        var tracker = new RuntimeMetricSummaryTracker();
+        var capturedAt = DateTimeOffset.Parse("2026-09-05T12:00:00Z", System.Globalization.CultureInfo.InvariantCulture);
+
+        IReadOnlyList<PrometheusSample> Samples(int generated, int accepted, int positionZero, int positionOne)
+        {
+            var raw = $"""
+                llamacpp:spec_decode_num_draft_tokens_total {generated}
+                llamacpp:spec_decode_num_accepted_tokens_total {accepted}
+                llamacpp:spec_decode_num_drafts_total 20484
+                """;
+            if (includePerPositionCounters)
+            {
+                raw += $"\nllamacpp:spec_decode_num_accepted_tokens_per_pos_total{{position=\"0\"}} {positionZero}"
+                    + $"\nllamacpp:spec_decode_num_accepted_tokens_per_pos_total{{position=\"1\"}} {positionOne}";
+            }
+            return RuntimeMetrics.ParsePrometheus(raw);
+        }
+
+        var first = tracker.Apply("runtime", Samples(40968, 33439, 17941, 15498), settings, null, null, capturedAt);
+
+        Assert.NotNull(first.Atomic);
+        Assert.Equal(40968, first.Atomic.MtpGeneratedTokens);
+        Assert.Equal(33439, first.Atomic.MtpAcceptedTokens);
+        Assert.Equal(81.622242, first.Atomic.DraftAcceptancePercent!.Value, 6);
+
+        var second = tracker.Apply("runtime", Samples(41068, 33519, 17986, 15533), settings, null, null, capturedAt.AddSeconds(2));
+
+        Assert.NotNull(second.Atomic);
+        Assert.Equal(41068, second.Atomic.MtpGeneratedTokens);
+        Assert.Equal(33519, second.Atomic.MtpAcceptedTokens);
+        Assert.Equal(50, second.GraphSample.SpeculativeGeneratedRate);
+        Assert.Equal(40, second.GraphSample.SpeculativeAcceptedRate);
+        Assert.Equal(40, second.Atomic.MtpAcceptedRate);
+    }
+
+    [Theory]
+    [InlineData("mtp")]
+    [InlineData("draft")]
+    [InlineData("speculative")]
+    [InlineData("spec")]
+    public void RuntimeAcceptedDraftCounterPreservesLabeledTotals(string family)
+    {
+        var samples = RuntimeMetrics.ParsePrometheus($$"""
+            llama_{{family}}_tokens_accepted_total{slot="0"} 30
+            llama_{{family}}_tokens_accepted_total{slot="1"} 45
+            llama_{{family}}_tokens_accepted_seconds_total 2
+            """);
+
+        Assert.Equal(75, RuntimeDashboardService.MtpAcceptedTokenCounter(samples));
+    }
+
     [Fact]
     public void RuntimeMetricSummaryTrackerUsesPerSlotRatesAcrossParallelSlotResets()
     {


### PR DESCRIPTION
The dashboard was counting accepted draft tokens twice by adding the per-position breakdown to the total. This made acceptance show 100% when it was actually about 81.6% in the reported example.

Fixed the counter filter, added regression tests for totals and rates, and updated the docs and Help text. The full local release gate passed, including 1,016 tests. Still needs a live check with the reporter's runtime.

Closes #59.
