### PR TITLE
Release v2.8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: version
     attributes:
       label: Application version
-      placeholder: v2.7.0
+      placeholder: v2.8.0
     validations:
       required: true
   - type: dropdown

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,27 +1,25 @@
 # Release Readiness Checklist
 
-Last updated: 2026-09-04
+Last updated: 2026-09-08
 
-The v2.7 release is explicitly unsigned and ships the installer and portable EXE
+The v2.8 release is explicitly unsigned and ships the installer and portable EXE
 with SHA-256 companions. See [UNSIGNED_RELEASE.md](UNSIGNED_RELEASE.md).
 
-The local unsigned preparation passed 987 tests (933 service/core and 54 WPF),
-the source/publish gate, standalone sidecar restoration, and pinned v2.6 portable
-replacement with data preservation. The packaged updater checked and staged a
-simulated future unsigned release using its real version with commit metadata.
-Live Proxmox-to-Manager tests passed missing/invalid/valid key handling, model
-discovery, inference and streaming through both the gateway and direct LAN
-endpoint. Changing text scale during a live stream did not interrupt it.
+Release scope and final validation are tracked in
+[release issue #68](https://github.com/alekk89/llama-cpp-windows-manager/issues/68).
+The candidate collects the completed benchmark, endpoint report, gateway,
+telemetry, draft-token accuracy, and hidden-section layout changes. The app,
+CLI, window labels, and installer all use version 2.8.0.
 
-Keyboard navigation, endpoint copying, light/dark readability and the candidate's
-large-scale sidebar were exercised. Cross-monitor dragging was confirmed by the
-owner. Spoken Narrator and Windows high-contrast presentation remain unverified;
-these are disclosed accessibility validation limits, not confirmed defects.
+Before publication, the exact merged commit must pass required PR checks and
+the clean Windows unsigned preparation workflow, including installer lifecycle,
+pinned v2.6 installer upgrade, and portable replacement. Release assets must
+embed that exact source commit. Record the successful runs and artifact review
+in the release issue; the dated checks below remain historical evidence.
 
-Before publication, the final commit must pass required PR checks and the clean
-Windows unsigned preparation workflow, including installer lifecycle, pinned
-v2.6 installer upgrade and portable replacement. Release assets must embed that
-exact source commit. Earlier dated counts below describe their audit phases.
+Live GPU benchmark execution, spoken Narrator, and Windows high-contrast
+presentation are not established by this release preparation. Existing saved
+data formats are unchanged by the release metadata update.
 
 ## Automated Gate
 
@@ -81,7 +79,7 @@ builds and must be described that way.
   gateway and control loads retain their explicit policies.
 
 - Publish the standalone `dist\LlamaCppWindowsManager-win-x64\LlamaCppWindowsManager.exe` from a clean checkout; do not publish a portable ZIP.
-- Build `dist\installer\LlamaCppWindowsManager-Setup-2.7.0-win-x64.exe` from the published app with Inno Setup 6.
+- Build `dist\installer\LlamaCppWindowsManager-Setup-2.8.0-win-x64.exe` from the published app with Inno Setup 6.
 - Confirm the publish folder contains no `.pdb` files.
 - Confirm the portable EXE and installer each have a matching `.sha256` companion file. For signed builds, generate the companion file after signing.
 - Confirm signed installer builds fail before compilation if `-SkipPublish`
@@ -598,8 +596,8 @@ builds and must be described that way.
 - Confirm manual Check For Updates shows a no-update popup when current, or an install confirmation when a newer release exists.
 - Confirm the release includes the installer and standalone EXE, each with a
   matching SHA-256 companion, and no portable ZIP. Checksum failures prevent staging.
-- Install unsigned v2.7 manually from v2.5 or v2.6; their existing updaters require signatures.
-- Confirm unsigned v2.7 can check and stage a subsequent checksum-verified unsigned release.
+- Install unsigned v2.8 manually from v2.5 or v2.6; their existing updaters require signatures.
+- Confirm unsigned v2.8 can check and stage a subsequent checksum-verified unsigned release.
 - Confirm a signed installed app refuses an unsigned or differently signed staged update.
 - Confirm a completed staged update restarts `LlamaCppWindowsManager.exe` and shows the GitHub release notes.
 - Confirm a non-critical staging-cleanup failure after successful replacement is
@@ -609,7 +607,7 @@ builds and must be described that way.
   failure, bounds background-task drain to 15 seconds, stops runtime sessions
   before tearing down local hosts/state, and records cleanup warnings.
 
-## Current 2.7 prerelease status
+## Historical 2.7 prerelease status
 
 The stabilized candidate includes the documented profile, naming, benchmark, and
 LAN changes plus the audit reliability fixes. The 2026-09-04 source and portable
@@ -756,7 +754,7 @@ either marker already exists, which prevents a temporary test from replacing a
 real installation's uninstall registration or shortcut.
 
 1. Start from a clean Windows VM.
-2. Install `dist\installer\LlamaCppWindowsManager-Setup-2.7.0-win-x64.exe`.
+2. Install `dist\installer\LlamaCppWindowsManager-Setup-2.8.0-win-x64.exe`.
 3. Confirm the installer prefers `D:\LlamaCppWindowsManager` when `D:` exists and allows choosing a different folder before install.
 4. Confirm the launch-after-install option opens the app.
 5. Confirm first launch creates `data\models`, `data\runtimes`, `data\cache`, `data\state`, and `data\logs` beside the exe when the install folder is writable.

--- a/docs/UNSIGNED_RELEASE.md
+++ b/docs/UNSIGNED_RELEASE.md
@@ -18,15 +18,15 @@ manual GitHub publication. Keep `TRUSTED_RELEASE_ENABLED` unset. Do not pass
    does not enable the disabled trusted workflow.
 5. Download the workflow artifact into an ignored workspace. From the clean
    checkout of the tagged commit, run `scripts/publish-unsigned-release.ps1`
-   with `-Tag v2.7.0 -AssetDirectory <downloaded-assets>` to create and verify a
+   with `-Tag v2.8.0 -AssetDirectory <downloaded-assets>` to create and verify a
    draft. After the release gates pass, rerun with `-Publish`. The script checks
    hashes, source commit and asset order before publication. Do not replace
    assets of an existing release; fix errors in a new version.
 
-For v2.7.0, the release assets are exactly:
+For v2.8.0, the release assets are exactly:
 
-- `Setup-LlamaCppWindowsManager-2.7.0-win-x64.exe`
-- `Setup-LlamaCppWindowsManager-2.7.0-win-x64.exe.sha256`
+- `Setup-LlamaCppWindowsManager-2.8.0-win-x64.exe`
+- `Setup-LlamaCppWindowsManager-2.8.0-win-x64.exe.sha256`
 - `LlamaCppWindowsManager.exe`
 - `LlamaCppWindowsManager.exe.sha256`
 
@@ -48,7 +48,7 @@ To reproduce preparation on a disposable Windows machine:
 
 ```powershell
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\test-release-gate.ps1 -RequireCleanTree -IncludePublish -IncludeInstaller -ReleaseChannel stable
-pwsh -NoProfile -File .\scripts\test-previous-version-upgrade.ps1 -CandidateInstallerPath .\dist\installer\LlamaCppWindowsManager-Setup-2.7.0-win-x64.exe
+pwsh -NoProfile -File .\scripts\test-previous-version-upgrade.ps1 -CandidateInstallerPath .\dist\installer\LlamaCppWindowsManager-Setup-2.8.0-win-x64.exe
 pwsh -NoProfile -File .\scripts\test-portable-update.ps1 -CandidateExePath .\dist\LlamaCppWindowsManager-win-x64\LlamaCppWindowsManager.exe
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\stage-unsigned-release.ps1
 ```
@@ -57,8 +57,8 @@ The installer tests refuse to modify an existing production installer identity.
 Use a disposable runner for those tests. Build-only preparation on a workstation
 does not establish that the installer lifecycle gate passed.
 
-The v2.5 and v2.6 updaters require signatures: users must install unsigned v2.7 manually
-once, retaining their data folder. Unsigned v2.7 supports subsequent official
+The v2.5 and v2.6 updaters require signatures: users must install unsigned v2.8 manually
+once, retaining their data folder. Unsigned builds from v2.7 onward support subsequent official
 HTTPS EXE updates with size and checksum verification. Signed builds retain
 mandatory signature and publisher checks. See
 [UPDATES_AND_RELEASE_VERIFICATION.md](UPDATES_AND_RELEASE_VERIFICATION.md).

--- a/docs/UPDATES_AND_RELEASE_VERIFICATION.md
+++ b/docs/UPDATES_AND_RELEASE_VERIFICATION.md
@@ -2,7 +2,7 @@
 
 ## Unsigned community releases
 
-Version 2.7 is an unsigned community release. Download the installer or standalone
+Version 2.8 is an unsigned community release. Download the installer or standalone
 `LlamaCppWindowsManager.exe` and its matching `.sha256` companion from
 [GitHub Releases](https://github.com/alekk89/llama-cpp-windows-manager/releases).
 The portable ZIP is no longer published. The EXE restores its bundled CLI,
@@ -18,11 +18,11 @@ if ($actual -ne $expected) { throw "Checksum mismatch" }
 Checksums detect mismatched downloads; they are not publisher signatures.
 Windows may display an unknown-publisher or SmartScreen prompt.
 
-The v2.5 and v2.6 updaters require signatures, so install unsigned v2.7 manually once.
+The v2.5 and v2.6 updaters require signatures, so install unsigned v2.8 manually once.
 Exit the Manager, then run the installer over the existing installation or
 replace the portable EXE in its existing folder. Keep the `data` folder.
 
-Unsigned v2.7 builds allow subsequent unsigned updates from the official GitHub
+Unsigned builds from v2.7 onward allow subsequent unsigned updates from the official GitHub
 repository over HTTPS. The updater requires the exact standalone EXE, matching
 tag URLs, a positive advertised size, and its SHA-256 companion. It checks the
 download size and checksum before staging, rejects non-newer versions, and labels

--- a/docs/releases/unreleased/23.md
+++ b/docs/releases/unreleased/23.md
@@ -1,2 +1,0 @@
-- Benchmarks now open with a quick test, with comparison settings, advanced runtime options, and clear tokens/s readouts above a compact results table.
-- Fixed configuration grouping, GPU argument formatting, incomplete-run detection, and imported settings; benchmark overrides leave saved profiles unchanged.

--- a/docs/releases/unreleased/43.md
+++ b/docs/releases/unreleased/43.md
@@ -1,1 +1,0 @@
-- Endpoint reports now use compact Runtimes-style tables with copyable model IDs, context, size, and useful settings. Extra details expand underneath, and API keys can be copied separately.

--- a/docs/releases/unreleased/53.md
+++ b/docs/releases/unreleased/53.md
@@ -1,1 +1,0 @@
-- Reduce gateway request-buffer allocations for large prompts while preserving request limits and runtime alias forwarding.

--- a/docs/releases/unreleased/54.md
+++ b/docs/releases/unreleased/54.md
@@ -1,1 +1,0 @@
-- Reuse the gateway routing catalog between model and profile changes, reducing repeated database reads and route lookup work.

--- a/docs/releases/unreleased/56.md
+++ b/docs/releases/unreleased/56.md
@@ -1,1 +1,0 @@
-- Show completed telemetry for the selected model before slower peer endpoints and GPU-summary refreshes finish.

--- a/docs/releases/unreleased/59.md
+++ b/docs/releases/unreleased/59.md
@@ -1,2 +1,0 @@
-- Fix double-counted accepted draft tokens when llama.cpp reports per-position
-  counters, restoring accurate draft acceptance percentages and token rates.

--- a/docs/releases/unreleased/65.md
+++ b/docs/releases/unreleased/65.md
@@ -1,1 +1,0 @@
-- Hidden Hugging Face, live log, and raw metrics sections no longer leave blank space when a saved layout is restored. Showing Hugging Face again restores a usable size.

--- a/docs/releases/v2.8.0.md
+++ b/docs/releases/v2.8.0.md
@@ -1,0 +1,13 @@
+- Benchmarks now open with a quick test, with profile comparisons and advanced runtime settings available when needed.
+- Benchmark results make prompt and generation tokens/s easier to read above a compact results table.
+- Fixed benchmark configuration grouping, GPU arguments, imported settings, and incomplete-run detection. One-off settings leave saved profiles unchanged.
+- Endpoint reports now use compact tables for model IDs, context, size, and settings, with extra details underneath.
+- Copy exact model IDs from endpoint reports, select field text, and copy API keys separately.
+- Large gateway prompts use fewer temporary allocations while preserving request limits and model alias forwarding.
+- Gateway routes are reused until models or profiles change, reducing repeated database reads and lookup work.
+- Selected-model metrics now appear without waiting for slower endpoints and GPU-summary refreshes.
+- Fixed double-counted accepted draft tokens, restoring accurate acceptance percentages and token rates.
+- Hiding Hugging Face, live logs, or raw metrics no longer leaves blank space when saved layouts are restored. Showing Hugging Face again restores a usable size.
+
+- This release is unsigned. From v2.5 or v2.6, install v2.8 manually once using the installer or portable EXE; keep your data folder.
+- Unsigned v2.7 users can update through the app with SHA-256 verification.

--- a/installer/LlamaCppWindowsManager.iss
+++ b/installer/LlamaCppWindowsManager.iss
@@ -1,7 +1,7 @@
 #define AppName "llama.cpp Windows Manager"
 #define AppExeName "LlamaCppWindowsManager.exe"
 #ifndef AppVersion
-#define AppVersion "2.7.0"
+#define AppVersion "2.8.0"
 #endif
 #ifndef SourceDir
 #define SourceDir "..\dist\LlamaCppWindowsManager-win-x64"

--- a/src/LocalLlmConsole.App/LocalLlmConsole.App.csproj
+++ b/src/LocalLlmConsole.App/LocalLlmConsole.App.csproj
@@ -11,10 +11,10 @@
     <AssemblyTitle>llama.cpp Windows Manager</AssemblyTitle>
     <Product>llama.cpp Windows Manager</Product>
     <RepositoryUrl>https://github.com/alekk89/llama-cpp-windows-manager</RepositoryUrl>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>v2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>v2.8.0</InformationalVersion>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>

--- a/src/LocalLlmConsole.App/MainWindow.xaml
+++ b/src/LocalLlmConsole.App/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:LocalLlmConsole"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
-        Title="llama.cpp Windows Manager v2.7.0" MinWidth="900" MinHeight="600" Width="1200" Height="780"
+        Title="llama.cpp Windows Manager v2.8.0" MinWidth="900" MinHeight="600" Width="1200" Height="780"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None" ResizeMode="CanResize"
         Background="{DynamicResource AppBack}"
@@ -58,7 +58,7 @@
                   CornerRadius="4"
                   VerticalAlignment="Center">
             <TextBlock x:Name="AppVersionText"
-                       Text="v2.7.0"
+                       Text="v2.8.0"
                        Foreground="{DynamicResource TextMuted}"
                        FontSize="10.5"
                        FontWeight="SemiBold"/>

--- a/src/LocalLlmConsole.App/Ui/Shell/MainWindow/Core/MainWindow.State.cs
+++ b/src/LocalLlmConsole.App/Ui/Shell/MainWindow/Core/MainWindow.State.cs
@@ -10,7 +10,7 @@ namespace LocalLlmConsole;
 public partial class MainWindow
 {
     private const string AppDisplayName = "llama.cpp Windows Manager";
-    private const string AppVersionLabel = "v2.7.0";
+    private const string AppVersionLabel = "v2.8.0";
 
     private readonly string _workspaceRoot;
     private readonly AppServiceFactory _serviceFactory;

--- a/src/LocalLlmConsole.ControlCli/LocalLlmConsole.ControlCli.csproj
+++ b/src/LocalLlmConsole.ControlCli/LocalLlmConsole.ControlCli.csproj
@@ -7,10 +7,10 @@
     <AssemblyName>llwmctl</AssemblyName>
     <RootNamespace>LocalLlmConsole.ControlCli</RootNamespace>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <Version>2.7.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
-    <InformationalVersion>v2.7.0</InformationalVersion>
+    <Version>2.8.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
+    <InformationalVersion>v2.8.0</InformationalVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />

--- a/tests/LocalLlmConsole.Tests/Release/ReleaseRepository.Tests.cs
+++ b/tests/LocalLlmConsole.Tests/Release/ReleaseRepository.Tests.cs
@@ -35,10 +35,10 @@ public sealed class ReleaseRepositoryTests : ManagerRegressionTestBase
     {
         var project = File.ReadAllText(FindRepositoryFile("src", "LocalLlmConsole.App", "LocalLlmConsole.App.csproj"));
 
-        Assert.Contains("<Version>2.7.0</Version>", project, StringComparison.Ordinal);
-        Assert.Contains("<AssemblyVersion>2.7.0.0</AssemblyVersion>", project, StringComparison.Ordinal);
-        Assert.Contains("<FileVersion>2.7.0.0</FileVersion>", project, StringComparison.Ordinal);
-        Assert.Contains("<InformationalVersion>v2.7.0</InformationalVersion>", project, StringComparison.Ordinal);
+        Assert.Contains("<Version>2.8.0</Version>", project, StringComparison.Ordinal);
+        Assert.Contains("<AssemblyVersion>2.8.0.0</AssemblyVersion>", project, StringComparison.Ordinal);
+        Assert.Contains("<FileVersion>2.8.0.0</FileVersion>", project, StringComparison.Ordinal);
+        Assert.Contains("<InformationalVersion>v2.8.0</InformationalVersion>", project, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/LocalLlmConsole.UiTests/Shell/MainWindowShell.Tests.cs
+++ b/tests/LocalLlmConsole.UiTests/Shell/MainWindowShell.Tests.cs
@@ -108,7 +108,7 @@ public sealed class WpfMainWindowShellTests : WpfUiTestBase
                 var statusY = statusCard.TranslatePoint(new Point(0, 0), windowContent).Y;
                 Assert.True(statusY > helpY + helpButton.ActualHeight, $"Help bottom {helpY + helpButton.ActualHeight}, status top {statusY}.");
                 Assert.True(statusY + statusCard.ActualHeight <= 680, $"Status bottom {statusY + statusCard.ActualHeight}.");
-                Assert.Equal("v2.7.0", appVersionText.Text);
+                Assert.Equal("v2.8.0", appVersionText.Text);
                 Assert.Equal(28, navigationToggle.Width);
                 var navigationToggleGlyph = Assert.IsType<TextBlock>(navigationToggle.Content);
                 Assert.Equal("\uE700", navigationToggleGlyph.Text);


### PR DESCRIPTION
Prepares the next unsigned release as v2.8.0, collecting the merged benchmark, endpoint report, gateway, telemetry, draft-token and hidden-section layout changes. The notes follow v2.7.0's short user-facing bullet style, with the unsigned upgrade guidance retained.

Updates the app, CLI, window labels, installer and version assertions together; consumes only the seven completed unreleased entries. Release preparation changes no saved-data formats or application behavior.

Validation: local source and portable release gate passed, including 1,116 tests (1,039 service/core and 77 WPF), three separate updater handoff checks, coverage thresholds, formatting, documentation, dependency audit and standalone publish verification.

After protected-main merge, run Prepare unsigned release on that exact commit for final clean-runner validation, installer lifecycle, the pinned v2.6 installer upgrade and portable replacement, then publish only its verified artifacts. Live GPU benchmark execution, Narrator and high-contrast presentation are not claimed by this preparation.

Refs #68. The release-planning issue stays open until publication and final validation evidence are recorded.
